### PR TITLE
feat: iOS Shortcuts support with magic byte detection (v1.2.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
   - Supports JPEG, PNG, GIF, WebP, HEIC, AVIF, MP4, MOV, BMP, TIFF
   - Filename extension no longer required for iOS Shortcuts uploads
   - Automatically appends correct extension if missing
+- Official iOS Shortcut for uploading photos, videos, and URLs
+  - Download link in docs/ios-shortcuts.md
+  - Handles photos, videos (MOV/MP4), and social media URLs
+  - Uses Encode Media passthrough for proper video handling
 
 ## [1.2.5] - 2026-01-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.6] - 2026-01-02
+
+### Added
+- Auto-detect file type from magic bytes in base64 upload endpoint
+  - Supports JPEG, PNG, GIF, WebP, HEIC, AVIF, MP4, MOV, BMP, TIFF
+  - Filename extension no longer required for iOS Shortcuts uploads
+  - Automatically appends correct extension if missing
+
 ## [1.2.5] - 2026-01-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.5] - 2026-01-01
+
+### Fixed
+- WebSocket disconnect error handling (RuntimeError when client disconnects)
+
 ## [1.2.4] - 2025-12-31
 
 ### Added

--- a/docs/ios-shortcuts.md
+++ b/docs/ios-shortcuts.md
@@ -1,365 +1,116 @@
 # iOS Shortcuts for immich-drop
 
-These shortcuts allow you to share photos, videos, and social media links directly to your Immich server.
+Upload photos, videos, and social media links directly to your Immich server from your iPhone or iPad.
 
-## Combined Shortcut: Save to Immich (Recommended - Base64 Method)
+## Download the Shortcut
 
-**Note:** This uses the base64 endpoint which is more reliable than multipart form uploads from iOS Shortcuts.
+**[Download "Save to Immich" Shortcut](https://www.icloud.com/shortcuts/fcd52bd36a3c4a569bae1d6dfe743756)**
 
-**Purpose**: Single shortcut that handles both file uploads AND URL downloads from TikTok, Instagram, Reddit, etc.
+This shortcut handles:
+- Photos (JPEG, HEIC, PNG, etc.)
+- Videos (MOV, MP4)
+- Social media URLs (TikTok, Instagram, Reddit, YouTube, Twitter/X)
 
-### Manual Creation
+## Setup
 
-1. Open the **Shortcuts** app
-2. Tap **+** to create a new shortcut
-3. Name it "Save to Immich"
-4. Add these actions in order:
+1. Tap the download link above on your iOS device
+2. Tap "Add Shortcut"
+3. **Important:** Edit the shortcut and update the `ServerName` variable to your immich-drop server URL:
+   - Example: `https://drop.yourdomain.com`
+   - Example: `http://192.168.1.100:8080`
 
-```
-1. Receive [Images, Media, Files, URLs, Text] input from [Share Sheet, Quick Actions]
-   - Show in Share Sheet: ON
+## Usage
 
-2. If [Shortcut Input] contains "http"
+### For Photos and Videos
 
-   =============== URL PATH ===============
-
-   3. Get Contents of URL
-      URL: https://YOUR_IMMICH_DROP_URL/api/upload/url
-      Method: POST
-      Headers:
-        Content-Type: application/json
-      Request Body: JSON
-      {
-        "url": "[Shortcut Input]"
-      }
-
-   4. Get Dictionary from Input
-      Input: [Contents of URL]
-
-   5. Get Dictionary Value
-      Get Value for Key: success
-      in Dictionary: [Dictionary]
-
-   6. If [Dictionary Value] equals 1
-
-      7. Get Dictionary Value
-         Get Value for Key: result
-         in Dictionary: [Dictionary]
-
-      8. Get Dictionary Value
-         Get Value for Key: filename
-         in Dictionary: [Dictionary Value]
-
-      9. Show Alert
-         Title: Saved to Immich
-         Message: [Dictionary Value]
-         Show Cancel Button: OFF
-
-   10. Otherwise
-
-      11. Get Dictionary Value
-          Get Value for Key: error
-          in Dictionary: [Dictionary]
-
-      12. Show Alert
-          Title: Upload Failed
-          Message: [Dictionary Value]
-
-   13. End If
-
-14. Otherwise
-
-   =============== FILE PATH (loops for multiple files) ===============
-
-   15. Number
-       Value: 0
-
-   16. Set Variable
-       Variable Name: uploadCount
-       (uses Number output above)
-
-   17. Number
-       Value: 0
-
-   18. Set Variable
-       Variable Name: errorCount
-       (uses Number output above)
-
-   19. Repeat with Each item in [Shortcut Input]
-
-      20. Base64 Encode
-          Input: [Repeat Item]
-          Line Breaks: None
-
-      21. Get Name
-          Input: [Repeat Item]
-
-      22. Set Variable
-          Variable Name: currentFilename
-
-      23. Get Contents of URL
-          URL: https://YOUR_IMMICH_DROP_URL/api/upload/base64
-          Method: POST
-          Request Body: JSON
-          Add fields:
-            - Key: data
-              Type: Text
-              Value: [Base64 Encoded]
-            - Key: filename
-              Type: Text
-              Value: [currentFilename]
-
-      24. Get Dictionary from Input
-          Input: [Contents of URL]
-
-      25. Get Dictionary Value
-          Get Value for Key: status
-          in Dictionary: [Dictionary]
-
-      26. If [Dictionary Value] equals "success"
-
-          27. Calculate
-              Calculate: [uploadCount] + 1
-
-          28. Set Variable
-              Variable Name: uploadCount
-              (uses Calculation Result)
-
-      29. Otherwise
-
-          30. Calculate
-              Calculate: [errorCount] + 1
-
-          31. Set Variable
-              Variable Name: errorCount
-              (uses Calculation Result)
-
-      32. End If
-
-   33. End Repeat
-
-   34. Show Alert
-       Title: Immich Upload Complete
-       Message: [uploadCount] uploaded, [errorCount] failed
-       Show Cancel Button: OFF
-
-35. End If
-```
-
-### Usage
-
-**For Photos/Videos:**
-1. Select photos/videos in Photos app (or any app)
-2. Tap Share button
+1. Select photos/videos in the Photos app (or any app)
+2. Tap the Share button
 3. Select "Save to Immich"
-4. All selected files upload with progress notification
+4. Files upload automatically
 
-**For Social Media URLs:**
-1. Open TikTok, Instagram, Reddit, YouTube, Twitter
+### For Social Media URLs
+
+1. Open TikTok, Instagram, Reddit, YouTube, or Twitter
 2. Find a video/post you want to save
 3. Tap Share -> "Save to Immich"
-4. Video downloads and uploads automatically
+4. The video downloads and uploads automatically
 
+## How It Works
 
----
+The shortcut:
+1. Detects if input is a URL or media file
+2. For URLs: Sends to `/api/upload/url` endpoint for server-side download
+3. For videos: Uses "Encode Media" with Passthrough to preserve raw video data
+4. For images: Encodes directly to base64
+5. Uploads via `/api/upload/base64` endpoint with auto-detected file type
 
-
-## Alternative: Separate Shortcuts
-
-If you prefer simpler, single-purpose shortcuts:
-
-### File Upload Only (Base64 Method)
-
-```
-1. Receive [Images, Media, Files] input from [Share Sheet]
-   - Show in Share Sheet: ON
-
-2. Number
-   Value: 0
-
-3. Set Variable
-   Variable Name: uploadCount
-
-4. Number
-   Value: 0
-
-5. Set Variable
-   Variable Name: errorCount
-
-6. Repeat with Each item in [Shortcut Input]
-
-   7. Base64 Encode
-      Input: [Repeat Item]
-      Line Breaks: None
-
-   8. Get Name
-      Input: [Repeat Item]
-
-   9. Set Variable
-      Variable Name: currentFilename
-
-   10. Get Contents of URL
-       URL: https://YOUR_IMMICH_DROP_URL/api/upload/base64
-       Method: POST
-       Request Body: JSON
-       Add fields:
-         - Key: data
-           Type: Text
-           Value: [Base64 Encoded]
-         - Key: filename
-           Type: Text
-           Value: [currentFilename]
-
-   11. Get Dictionary from Input
-       Input: [Contents of URL]
-
-   12. Get Dictionary Value
-       Get Value for Key: status
-       in Dictionary: [Dictionary]
-
-   13. If [Dictionary Value] equals "success"
-
-       14. Calculate
-           Calculate: [uploadCount] + 1
-
-       15. Set Variable
-           Variable Name: uploadCount
-
-   16. Otherwise
-
-       17. Calculate
-           Calculate: [errorCount] + 1
-
-       18. Set Variable
-           Variable Name: errorCount
-
-   19. End If
-
-20. End Repeat
-
-21. Show Alert
-    Title: Immich Upload
-    Message: [uploadCount] uploaded, [errorCount] failed
-    Show Cancel Button: OFF
-```
-
-### URL Upload Only
-
-```
-1. Receive [URLs, Text] input from [Share Sheet]
-   - Show in Share Sheet: ON
-
-2. Get Contents of URL
-   URL: https://YOUR_IMMICH_DROP_URL/api/upload/url
-   Method: POST
-   Headers:
-     Content-Type: application/json
-   Request Body: JSON
-   {
-     "url": "[Shortcut Input]"
-   }
-
-3. Get Dictionary from Input
-   Input: [Contents of URL]
-
-4. Get Dictionary Value
-   Get Value for Key: success
-   in Dictionary: [Dictionary]
-
-5. If [Dictionary Value] equals 1
-
-   6. Get Dictionary Value
-      Get Value for Key: result
-      in Dictionary: [Dictionary]
-
-   7. Get Dictionary Value
-      Get Value for Key: filename
-      in Dictionary: [Dictionary Value]
-
-   8. Show Alert
-      Title: Saved to Immich
-      Message: [Dictionary Value]
-      Show Cancel Button: OFF
-
-9. Otherwise
-
-   10. Get Dictionary Value
-       Get Value for Key: error
-       in Dictionary: [Dictionary]
-
-   11. Show Alert
-       Title: Upload Failed
-       Message: [Dictionary Value]
-
-12. End If
-```
-
+The server automatically detects file types from magic bytes, so filename extensions are optional.
 
 ---
-
-
-## Configuration
-
-Replace `YOUR_IMMICH_DROP_URL` with your actual immich-drop server URL:
-- `https://drop.yourdomain.com`
-- `http://192.168.1.100:8080`
-
-### Optional: Album Parameter
-
-Add `album_name` to save uploads to a specific album:
-
-**For URL uploads** (JSON body):
-```json
-{
-  "url": "[Shortcut Input]",
-  "album_name": "Social Media Saves"
-}
-```
-
-**For file uploads** (Form field):
-- Add another Form field:
-  - Type: Text
-  - Key: album_name
-  - Value: "Camera Uploads"
-
-
----
-
 
 ## Troubleshooting
 
 ### "Request failed" or timeout errors
-- Check your server URL is correct
+- Check your server URL is correct in the `ServerName` variable
 - Ensure your server is accessible from your phone (not just local network if on cellular)
-- Large videos may take time to download - be patient
+- Large videos may take time to process - be patient
+
+### "The network connection was lost"
+- This usually means the request body wasn't sent correctly
+- Make sure you're using the official shortcut from the link above
 
 ### "Unsupported URL" error
 - Make sure you're sharing the video/post URL, not just text
 - Supported platforms: TikTok, Instagram, Reddit, YouTube, Twitter/X
 
-### Only one file uploads (FIXED)
-- The updated shortcut uses "Repeat with Each" to upload files individually
-- Make sure you're using the new shortcut instructions above
-
 ### Videos not downloading from Instagram
 - Instagram stories/posts may require authentication
+- Configure platform cookies in the immich-drop admin menu
 - Try public posts first
 
 ### "413 Request Entity Too Large"
-- If using reverse proxy (nginx, Traefik), increase body size limit
+- If using a reverse proxy (nginx, Traefik), increase body size limit
 - For nginx: `client_max_body_size 500M;`
 
+### Images appear corrupted
+- Make sure you're using the latest shortcut version
+- The shortcut uses "Encode Media" for videos and direct base64 for images
+- Server v1.2.6+ auto-detects file types from content
 
 ---
-
 
 ## API Reference
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
 | `/api/upload/base64` | POST | Upload base64-encoded file (JSON: data, filename) - Recommended for iOS |
-| `/api/upload/file` | POST | Upload single file (Form: file) |
-| `/api/upload/batch` | POST | Upload multiple files (Form: files[]) |
 | `/api/upload/url` | POST | Download and upload from URL (JSON: url) |
-| `/api/upload/urls` | POST | Batch URL downloads (JSON: urls[]) |
+| `/api/upload/urls` | POST | Batch URL downloads (JSON: urls[], max 10) |
 | `/api/supported-platforms` | GET | List supported URL platforms |
+
+### Base64 Upload Format
+
+```json
+{
+  "data": "base64-encoded-file-content",
+  "filename": "optional-filename.jpg",
+  "album_name": "optional-album-name"
+}
+```
+
+The server auto-detects file type from magic bytes. Supported formats:
+- Images: JPEG, PNG, GIF, WebP, HEIC, AVIF, BMP, TIFF
+- Videos: MP4, MOV
+
+---
+
+## Manual Shortcut Creation
+
+If you prefer to create the shortcut manually or want to customize it, the key components are:
+
+1. **URL Detection**: Check if input contains "http" to route to URL upload
+2. **Video Detection**: Use "Get Details of Images" -> "File Extension" to detect .mov/.mp4
+3. **Video Processing**: Use "Encode Media" with Size: Passthrough before base64 encoding
+4. **Image Processing**: Base64 encode directly with Line Breaks: None
+5. **JSON Body**: Build manually with Text action, send as Request Body: File
+6. **Result Handling**: Store upload result in a variable before End If to handle both paths

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.2.4"
+VERSION = "1.2.5"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.2.5"
+VERSION = "1.2.6"


### PR DESCRIPTION
## Summary

- Add auto-detection of file types from magic bytes in base64 upload endpoint
- Fix WebSocket disconnect error handling (v1.2.5)
- Add official iOS Shortcut with iCloud download link

## Changes

### Magic Byte Detection (v1.2.6)
- New `detect_file_type()` function identifies files by content, not extension
- Supports: JPEG, PNG, GIF, WebP, HEIC, AVIF, MP4, MOV, BMP, TIFF
- iOS Shortcuts no longer need to provide filename extensions

### WebSocket Fix (v1.2.5)
- Handle RuntimeError when client disconnects during WebSocket communication

### iOS Shortcuts Documentation
- Simplified docs to reference official iCloud shortcut link
- Shortcut handles photos, videos (MOV/MP4), and social media URLs
- Uses Encode Media passthrough for proper video handling

## Test plan

- [ ] Upload image via base64 endpoint without filename extension
- [ ] Upload video via base64 endpoint without filename extension
- [ ] Test iOS Shortcut with photos, videos, and URLs
- [ ] Verify WebSocket uploads still work after client disconnect