### PR TITLE
feat: Facebook Reels support with iOS Shortcut fix (v1.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 - Facebook downloads: Force mp4 output format to prevent corrupt files in Immich
   - Changed format selection to prefer mp4 containers with `--merge-output-format mp4`
   - Previous `bestvideo+bestaudio/best` could produce .webm/.mkv that Immich cannot play
+- iOS Shortcut: Updated URL detection from "contains http" text check to "Get URLs from Input"
+  - Facebook's share sheet passes URLs in a format the old text check could not detect
+  - Shortcut was falling through to base64 path and uploading a thumbnail instead of the video
+  - New approach uses "Get URLs from Input" + "Get First Item from List" for reliable extraction
 
 ### Added
 - Debug logging for yt-dlp downloads (command, stderr, metadata, file size, format)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.9] - 2026-02-15
+
+### Fixed
+- Facebook downloads: Force mp4 output format to prevent corrupt files in Immich
+  - Changed format selection to prefer mp4 containers with `--merge-output-format mp4`
+  - Previous `bestvideo+bestaudio/best` could produce .webm/.mkv that Immich cannot play
+
+### Added
+- Debug logging for yt-dlp downloads (command, stderr, metadata, file size, format)
+- Warning log when downloaded file is very small (likely a thumbnail instead of video)
+- Upload logging with filename, content type, and file size before sending to Immich
+- Facebook added to iOS Shortcuts and README supported platform lists
+
 ## [1.2.8] - 2026-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to this project will be documented in this file.
   - Supported URL formats: /reel/, /videos/, /watch, /share/v/, /share/r/, fb.watch short links
   - Cookie support for authenticated Facebook downloads
   - Video-first format selection to prevent thumbnail-only downloads
+  - Browser impersonation for Facebook downloads (bypasses bot detection)
 
 ### Changed
 - Unpinned yt-dlp version (always pulls latest on build, was previously pinned to >=2024.1.0)
+- Added curl_cffi dependency for yt-dlp browser impersonation support
 
 ## [1.2.7] - 2026-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.8] - 2026-02-15
+
+### Added
+- Facebook Reels and video support (URL downloads via yt-dlp)
+  - Supported URL formats: /reel/, /videos/, /watch, /share/v/, /share/r/, fb.watch short links
+  - Cookie support for authenticated Facebook downloads
+  - Video-first format selection to prevent thumbnail-only downloads
+
+### Changed
+- Unpinned yt-dlp version (always pulls latest on build, was previously pinned to >=2024.1.0)
+
 ## [1.2.7] - 2026-01-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Admin users log in to create public invite links; invite links are always public
 - **Chunked Uploads (optional):** large-file support with configurable chunk size
 - **Privacy-first:** never lists server media; session-local uploads only
 - **Mobile + Dark Mode:** responsive UI, safe-area padding, persistent theme
-- **URL Downloads:** download from TikTok, Instagram, Reddit, YouTube, Twitter and upload to Immich
+- **URL Downloads:** download from TikTok, Instagram, Facebook, Reddit, YouTube, Twitter and upload to Immich
 - **Platform Cookies:** add authentication cookies for platforms requiring login (Instagram, TikTok, etc.)
 - **iOS Shortcuts:** share photos/videos or social media URLs directly from your iPhone ([setup guide](docs/ios-shortcuts.md))
 
@@ -109,7 +109,7 @@ docker compose up -d
 Share photos, videos, and social media links directly from your iPhone to Immich.
 
 **Features:**
-- Single shortcut handles both files AND URLs (TikTok, Instagram, Reddit, YouTube, Twitter)
+- Single shortcut handles both files AND URLs (TikTok, Instagram, Facebook, Reddit, YouTube, Twitter)
 - Upload multiple photos/videos at once
 - Shows upload progress notifications
 
@@ -124,6 +124,7 @@ Upload content from social media platforms directly via the web UI or API:
 **Supported Platforms:**
 - TikTok
 - Instagram (Reels, Posts)
+- Facebook (Reels, Videos)
 - Reddit (videos, images)
 - YouTube (Shorts, videos)
 - Twitter/X

--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -254,6 +254,7 @@ def create_api_routes(config):
                 "reddit": "https://www.reddit.com/r/subreddit/comments/abc123/title",
                 "youtube": "https://www.youtube.com/shorts/ABC123",
                 "twitter": "https://twitter.com/user/status/123456789",
+                "facebook": "https://www.facebook.com/reel/123456789",
             }
         )
 

--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -12,7 +12,10 @@ import hashlib
 import httpx
 import os
 import base64
+import logging
 import mimetypes
+
+logger = logging.getLogger("immich_drop.api_routes")
 
 from .url_downloader import (
     download_from_url,
@@ -280,6 +283,8 @@ def create_api_routes(config):
                 detail=f"Unsupported URL. Supported platforms: {', '.join(SUPPORTED_PATTERNS.keys())}"
             )
 
+        logger.info("URL upload request: platform=%s url=%s", platform, url)
+
         # Look up cookies for this platform (if configured)
         cookies_file = get_cookie_file_for_platform(platform, config.state_db)
 
@@ -287,6 +292,7 @@ def create_api_routes(config):
         download_result = await download_from_url(url, cookies_file=cookies_file)
 
         if not download_result.success:
+            logger.error("Download failed for %s: %s", url, download_result.error)
             return UrlUploadResponse(
                 success=False,
                 error=download_result.error,
@@ -296,6 +302,13 @@ def create_api_routes(config):
             # Read file content
             with open(download_result.filepath, "rb") as f:
                 file_content = f.read()
+
+            logger.info(
+                "Uploading to Immich: filename=%s content_type=%s size=%d bytes",
+                download_result.filename,
+                download_result.content_type,
+                len(file_content),
+            )
 
             # Extract timestamp from metadata if available
             file_created_at = None

--- a/app/cookie_manager.py
+++ b/app/cookie_manager.py
@@ -17,6 +17,7 @@ PLATFORM_DOMAINS = {
     "instagram": ".instagram.com",
     "tiktok": ".tiktok.com",
     "twitter": ".twitter.com",
+    "facebook": ".facebook.com",
     "reddit": ".reddit.com",
     "youtube": ".youtube.com",
 }

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -1,6 +1,6 @@
 """
 URL Downloader module for immich-drop
-Downloads videos/images from TikTok, Instagram, Reddit using yt-dlp
+Downloads videos/images from TikTok, Instagram, Facebook, Reddit using yt-dlp
 """
 import os
 import re
@@ -49,6 +49,14 @@ SUPPORTED_PATTERNS = {
     ],
     'twitter': [
         r'(?:https?://)?(?:www\.)?(?:twitter|x)\.com/[\w]+/status/\d+',
+    ],
+    'facebook': [
+        r'(?:https?://)?(?:www\.)?facebook\.com/reel/\d+',
+        r'(?:https?://)?(?:www\.)?facebook\.com/[\w.]+/videos/\d+',
+        r'(?:https?://)?(?:www\.)?facebook\.com/watch/?\?v=\d+',
+        r'(?:https?://)?(?:www\.)?facebook\.com/share/v/[\w]+',
+        r'(?:https?://)?(?:www\.)?facebook\.com/share/r/[\w]+',
+        r'(?:https?://)?fb\.watch/[\w]+',
     ],
 }
 
@@ -132,6 +140,10 @@ async def download_from_url(
     elif platform == 'twitter':
         cmd.extend([
             "--format", "best",
+        ])
+    elif platform == 'facebook':
+        cmd.extend([
+            "--format", "bestvideo+bestaudio/best",
         ])
 
     cmd.append(url)

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -144,6 +144,7 @@ async def download_from_url(
     elif platform == 'facebook':
         cmd.extend([
             "--format", "bestvideo+bestaudio/best",
+            "--impersonate", "chrome",
         ])
 
     cmd.append(url)

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -7,12 +7,15 @@ import re
 import tempfile
 import asyncio
 import hashlib
+import logging
 from pathlib import Path
 from typing import Optional, Tuple, List
 from dataclasses import dataclass
 from datetime import datetime
 import subprocess
 import json
+
+logger = logging.getLogger("immich_drop.url_downloader")
 
 
 @dataclass
@@ -143,11 +146,14 @@ async def download_from_url(
         ])
     elif platform == 'facebook':
         cmd.extend([
-            "--format", "bestvideo+bestaudio/best",
+            "--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio/best[ext=mp4]/best",
+            "--merge-output-format", "mp4",
             "--impersonate", "chrome",
         ])
 
     cmd.append(url)
+
+    logger.info("yt-dlp command: %s", " ".join(cmd))
 
     try:
         # Run yt-dlp
@@ -159,8 +165,14 @@ async def download_from_url(
 
         stdout, stderr = await process.communicate()
 
+        if stderr:
+            stderr_text = stderr.decode().strip()
+            if stderr_text:
+                logger.warning("yt-dlp stderr: %s", stderr_text)
+
         if process.returncode != 0:
             error_msg = stderr.decode().strip() if stderr else "Unknown error"
+            logger.error("yt-dlp failed (exit %d): %s", process.returncode, error_msg)
             # Clean up temp dir if we created it
             if output_dir and output_dir.startswith(tempfile.gettempdir()):
                 import shutil
@@ -180,11 +192,21 @@ async def download_from_url(
                         metadata = json.loads(line)
                         break
             except json.JSONDecodeError:
-                pass
+                logger.warning("Failed to parse yt-dlp JSON output")
+
+        if metadata:
+            logger.info(
+                "yt-dlp metadata: format=%s ext=%s resolution=%s filesize=%s",
+                metadata.get("format"),
+                metadata.get("ext"),
+                metadata.get("resolution"),
+                metadata.get("filesize") or metadata.get("filesize_approx"),
+            )
 
         # Find the downloaded file
         downloaded_files = list(Path(output_dir).glob("*"))
         if not downloaded_files:
+            logger.error("yt-dlp returned 0 but no file found in %s", output_dir)
             return DownloadResult(
                 success=False,
                 error="No file was downloaded"
@@ -192,6 +214,16 @@ async def download_from_url(
 
         filepath = str(downloaded_files[0])
         filename = downloaded_files[0].name
+        file_size = downloaded_files[0].stat().st_size
+        logger.info(
+            "Downloaded file: %s (size=%d bytes, ext=%s)",
+            filename, file_size, downloaded_files[0].suffix,
+        )
+        if file_size < 10000:
+            logger.warning(
+                "Downloaded file is very small (%d bytes) -- likely a thumbnail or error page",
+                file_size,
+            )
 
         # Determine content type
         ext = downloaded_files[0].suffix.lower()

--- a/docs/ios-shortcuts.md
+++ b/docs/ios-shortcuts.md
@@ -9,7 +9,7 @@ Upload photos, videos, and social media links directly to your Immich server fro
 This shortcut handles:
 - Photos (JPEG, HEIC, PNG, etc.)
 - Videos (MOV, MP4)
-- Social media URLs (TikTok, Instagram, Reddit, YouTube, Twitter/X)
+- Social media URLs (TikTok, Instagram, Facebook, Reddit, YouTube, Twitter/X)
 
 ## Setup
 
@@ -30,7 +30,7 @@ This shortcut handles:
 
 ### For Social Media URLs
 
-1. Open TikTok, Instagram, Reddit, YouTube, or Twitter
+1. Open TikTok, Instagram, Facebook, Reddit, YouTube, or Twitter
 2. Find a video/post you want to save
 3. Tap Share -> "Save to Immich"
 4. The video downloads and uploads automatically
@@ -61,7 +61,7 @@ The server automatically detects file types from magic bytes, so filename extens
 
 ### "Unsupported URL" error
 - Make sure you're sharing the video/post URL, not just text
-- Supported platforms: TikTok, Instagram, Reddit, YouTube, Twitter/X
+- Supported platforms: TikTok, Instagram, Facebook, Reddit, YouTube, Twitter/X
 
 ### Videos not downloading from Instagram
 - Instagram stories/posts may require authentication
@@ -71,6 +71,11 @@ The server automatically detects file types from magic bytes, so filename extens
 ### "413 Request Entity Too Large"
 - If using a reverse proxy (nginx, Traefik), increase body size limit
 - For nginx: `client_max_body_size 500M;`
+
+### Facebook Reels show "Unsupported URL" error
+- Make sure your immich-drop server is v1.2.8 or later
+- Supported URL formats: /reel/, /videos/, /watch, /share/v/, /share/r/, fb.watch short links
+- If using a private video, configure Facebook cookies in the admin menu
 
 ### Images appear corrupted
 - Make sure you're using the latest shortcut version

--- a/frontend/url-uploader.js
+++ b/frontend/url-uploader.js
@@ -25,7 +25,7 @@ class UrlUploader {
                 <div class="url-input-section">
                     <h3 class="text-lg font-semibold mb-2 dark:text-white">Upload from URL</h3>
                     <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-                        Paste a link from TikTok, Instagram, Reddit, YouTube, or Twitter
+                        Paste a link from TikTok, Instagram, Facebook, Reddit, YouTube, or Twitter
                     </p>
 
                     <div style="display: flex; flex-direction: column; gap: 0.5rem;">

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ urllib3==2.5.0
 uvicorn==0.35.0
 watchfiles==1.1.0
 websockets==15.0.1
-yt-dlp>=2024.1.0
+yt-dlp

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ urllib3==2.5.0
 uvicorn==0.35.0
 watchfiles==1.1.0
 websockets==15.0.1
-yt-dlp
+yt-dlp[default,curl_cffi]

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.2.7"
+VERSION = "1.2.8"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.2.8"
+VERSION = "1.2.9"


### PR DESCRIPTION
## Summary
- Add Facebook Reels and video download support via yt-dlp with browser impersonation
- Fix corrupt file uploads by forcing mp4 output format for Facebook downloads
- Fix iOS Shortcut URL detection for Facebook shares using "Get URLs from Input" action
- Add debug logging for yt-dlp downloads (command, metadata, file size, format)

## Changes

### Server (v1.2.8)
- Facebook URL pattern support: /reel/, /videos/, /watch, /share/v/, /share/r/, fb.watch
- Browser impersonation (`--impersonate chrome`) to bypass Facebook bot detection
- Cookie support for authenticated Facebook downloads
- curl_cffi dependency added for impersonation support

### Server (v1.2.9)
- Force mp4 output with `--merge-output-format mp4` (previous `bestvideo+bestaudio/best` could produce .webm/.mkv that Immich cannot play)
- Debug logging throughout yt-dlp download pipeline: command, stderr, metadata, file details, upload parameters
- Small file warning when download is < 10KB (likely thumbnail)

### iOS Shortcut (v1.2.9)
- Replaced "contains http" text check with "Get URLs from Input" + "Get First Item from List"
- Facebook share sheet passes URLs in a non-text format the old check could not detect
- Documented upgrade steps for existing shortcuts

### Docs
- Facebook added to supported platform lists in README and iOS Shortcuts guide
- New "Updating an Existing Shortcut" section with step-by-step upgrade instructions
- Facebook-specific troubleshooting entries

## Test plan
- [x] Facebook Reel via web UI -- downloads as mp4, plays in Immich
- [x] Facebook Reel via iOS Shortcut -- URL extracted, sent to /api/upload/url, mp4 uploaded
- [x] TikTok via iOS Shortcut -- still works
- [x] Instagram Reel via iOS Shortcut -- still works
- [x] Logs confirm all downloads hit /api/upload/url with correct metadata
