### PR TITLE
Direct image downloads, platform extraction, SSRF fix, UI redesign (v1.3.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 *.env
 agent.md
 docker-compose.yml
+.claude
+.playwright/
+.playwright-mcp/
+.benchmark/
 # Python cache and build artifacts
 __pycache__/
 app/__pycache__/*
@@ -16,6 +20,7 @@ build/
 dist/
 
 # Virtual envs and IDE
+venv/
 .venv/
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.4] - 2026-02-25
+
+### Fixed
+- SSRF vulnerability in direct image URL downloads
+  - `download_direct_image()` accepted URLs targeting private/internal networks (169.254.x.x, 10.x.x.x, 127.0.0.1, etc.)
+  - Added `_validate_url_target()` that resolves hostnames and blocks private, loopback, link-local, and reserved IP ranges
+  - Blocks non-HTTP(S) schemes (file://, ftp://, etc.)
+  - Redirect targets are validated via httpx event hook to prevent redirect-based SSRF bypasses
+
+### Changed
+- Merged duplicate `_best_image_url()` and `_best_video_url()` into single `_best_media_url()` helper
+- Removed unused `client` parameter from `_instagram_fallback_chain()` and `_instagram_og_image_fallback()`
+  - Each fallback function now creates its own `httpx.AsyncClient` (self-contained for failure paths)
+
 ## [1.3.3] - 2026-02-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.3] - 2026-02-25
+
+### Fixed
+- Instagram image posts still failing when og:image meta tags are absent (JS-rendered pages)
+  - Added oEmbed fallback (`/api/v1/oembed/`) that works without authentication
+  - Returns 640x800 CDN thumbnail URL -- sufficient for image post extraction
+  - New fallback chain: API -> oEmbed -> og:image scraping
+  - oEmbed is tried before og:image since it is more reliable for unauthenticated requests
+
+### Added
+- `_instagram_oembed_fallback()` -- Instagram oEmbed API client for thumbnail extraction
+- `_instagram_fallback_chain()` -- unified fallback wrapper (oEmbed then og:image)
+
 ## [1.3.2] - 2026-02-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.5] - 2026-02-25
+
+### Fixed
+- Critical: Direct image downloads (i.redd.it, imgur, etc.) crashing with TypeError
+  - The `_validate_redirect` SSRF event hook was a sync function but httpx AsyncClient requires async hooks
+  - Changed to `async def` -- function body needs no await calls, which is valid for async functions
+- Instagram story URLs matching the platform pattern but failing extraction
+  - Story URLs (`/stories/username/media_id/`) were routed to `extract_instagram_media_urls()` which expects a shortcode
+  - Added `_is_instagram_story_url()` helper to detect story URLs before routing
+  - Added `extract_instagram_story_urls()` using Instagram private API (web_profile_info + reels_media)
+  - Resolves username to user_id, fetches active stories, matches specific story by pk/id
+  - Requires cookies (stories are only visible to authenticated users)
+
+### Added
+- Multi-item response visibility for single URL endpoint (`POST /api/upload/url`)
+  - `UrlUploadResponse` now includes `total_uploaded` count and `additional_results` list
+  - Frontend shows count when multiple items uploaded (e.g., "Successfully uploaded 5 items!")
+  - All carousel/gallery items rendered individually in the results list
+  - Backward compatible: new fields have defaults (`total_uploaded=0`, `additional_results=[]`)
+
 ## [1.3.4] - 2026-02-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2026-02-25
+
+### Added
+- Direct image URL download support (bypasses yt-dlp for image files)
+  - Downloads images via httpx with browser User-Agent, redirect following, and 100MB size limit
+  - File type detection via magic bytes (reuses shared detect_file_type utility)
+  - Known image-hosting domains: i.redd.it, i.imgur.com, pbs.twimg.com, preview.redd.it
+  - Any URL ending in .jpg, .jpeg, .png, .gif, .webp, .avif, .heic, .bmp, .tiff
+  - Works in both single and batch upload endpoints
+- Reddit URL patterns for i.redd.it and preview.redd.it image domains
+
+### Fixed
+- Reddit downloads failing with HTTP 429 (Too Many Requests)
+  - Added browser impersonation (`--impersonate chrome`) for Reddit, matching existing Facebook fix
+
+### Changed
+- Extracted detect_file_type into shared app/utils.py module (used by both api_routes and url_downloader)
+- Updated frontend description text to mention direct image URL support
+- is_supported_url now returns True for direct image URLs (not just platform-matched URLs)
+
 ## [1.2.9] - 2026-02-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ All notable changes to this project will be documented in this file.
   - Redirect targets are validated via httpx event hook to prevent redirect-based SSRF bypasses
 
 ### Changed
+- Complete frontend UI redesign -- consistent styling across all pages, mobile-friendly
+  - Replaced Tailwind CDN with custom `styles.css` using CSS custom properties for theming
+  - DM Sans font for body text, JetBrains Mono for code/monospace
+  - Unified component library: `.btn`, `.card`, `.input`, `.badge`, `.banner`, `.data-table`
+  - Dark mode via CSS variables (no Tailwind dark: prefix classes)
+  - Responsive tables: 7-column manage links table converts to stacked card layout on mobile
+  - Admin menu page header no longer overflows on small screens
+  - Login page centered with proper form card
+  - Upload progress items use DOM construction (no innerHTML with filenames)
+  - Extracted menu.js from inline script in menu.html
 - Merged duplicate `_best_image_url()` and `_best_video_url()` into single `_best_media_url()` helper
 - Removed unused `client` parameter from `_instagram_fallback_chain()` and `_instagram_og_image_fallback()`
   - Each fallback function now creates its own `httpx.AsyncClient` (self-contained for failure paths)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2026-02-25
+
+### Fixed
+- Reddit image posts failing with HTTP 429 (Too Many Requests)
+  - Bypasses yt-dlp entirely for image posts: fetches Reddit JSON directly via httpx
+  - Extracts image URLs from gallery posts (multi-image) and single image posts
+  - Constructs direct `i.redd.it` URLs from media_metadata for original quality
+  - Removed `--impersonate chrome` from Reddit yt-dlp args (did not fix 429)
+  - Video posts still fall through to yt-dlp as before
+- Instagram image posts failing with "No video formats found"
+  - Uses Instagram REST API (`?__a=1&__d=dis`) to extract media URLs directly
+  - Handles carousel posts (mixed images + videos), single images, and single videos
+  - Selects highest resolution from available candidates
+  - Falls back to og:image meta tag scraping if API endpoint fails
+  - Reels and video-only posts still fall through to yt-dlp
+
+### Added
+- Gallery/carousel support: single URL uploads now handle multi-image posts
+  - Reddit galleries download all images from the post
+  - Instagram carousels download all images and videos from the post
+  - All items uploaded to Immich; primary response returns first item
+- `extract_reddit_image_urls()` -- Reddit post JSON parser for image extraction
+- `extract_instagram_media_urls()` -- Instagram API client for media extraction
+- `download_platform_media()` -- unified platform-specific media downloader
+- `download_from_url_multi()` -- multi-result wrapper for gallery support
+
 ## [1.3.0] - 2026-02-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ All notable changes to this project will be documented in this file.
   - All carousel/gallery items rendered individually in the results list
   - Backward compatible: new fields have defaults (`total_uploaded=0`, `additional_results=[]`)
 
+### Changed
+- Adopted Immich brand colors throughout the UI
+  - Primary accent: `#4250af` (light mode) / `#accbfa` (dark mode) matching Immich's own `--immich-primary`
+  - Applied to buttons, input focus rings, dropzone drag state, platform tags, and footer links
+  - Added `--accent-hover`, `--accent-subtle`, and `--shadow-focus` design tokens
+- Fixed platform tags ("Supported:" line) displaying as unstyled run-together text
+  - CSS selector `.url-section .platform-tags` never matched (parent class is `url-uploader`)
+  - Changed to `.platform-tags` -- flex layout with gap now applies, tags display as spaced badges
+- Platform tags now use accent-subtle background with accent-colored text instead of plain gray
+
 ## [1.3.4] - 2026-02-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2026-02-25
+
+### Fixed
+- Instagram image posts still failing with "No video formats found" despite v1.3.1 extraction
+  - Cookies were never threaded through to `extract_instagram_media_urls()` -- the `?__a=1&__d=dis` API endpoint returns 404 without auth
+  - Added `cookies_file` parameter to `download_platform_media()` and `extract_instagram_media_urls()`
+  - `download_from_url_multi()` now passes `cookies_file` to platform-specific extractors
+  - Cookies also passed to `_instagram_og_image_fallback()` for login-walled pages
+- Instagram CDN image downloads failing when CDN rejects HEAD requests
+  - HEAD pre-check is now non-fatal: logs a debug message and proceeds with GET
+- Hardened og:image fallback regex to handle both `property/content` and `content/property` attribute orderings
+
+### Added
+- `parse_netscape_cookies()` helper to read Netscape cookie files into HTTP Cookie header strings
+
 ## [1.3.1] - 2026-02-25
 
 ### Fixed

--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -68,6 +68,8 @@ class UrlUploadResponse(BaseModel):
     success: bool
     result: Optional[UploadResult] = None
     error: Optional[str] = None
+    total_uploaded: int = 0
+    additional_results: List[UploadResult] = []
 
 
 class BatchUploadResponse(BaseModel):
@@ -255,6 +257,7 @@ def create_api_routes(config):
 
         source_label = platform or "direct_image"
         primary_upload_result = None
+        all_upload_results = []
         total_uploaded = 0
 
         try:
@@ -295,6 +298,8 @@ def create_api_routes(config):
                 if upload_result.status == "success":
                     total_uploaded += 1
 
+                all_upload_results.append(upload_result)
+
                 # Keep first result as the primary response
                 if primary_upload_result is None:
                     primary_upload_result = upload_result
@@ -309,6 +314,8 @@ def create_api_routes(config):
                 success=primary_upload_result.status == "success",
                 result=primary_upload_result,
                 error=primary_upload_result.error,
+                total_uploaded=total_uploaded,
+                additional_results=all_upload_results[1:],
             )
 
         finally:

--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -23,64 +23,14 @@ from .url_downloader import (
     cleanup_download,
     is_supported_url,
     identify_platform,
+    is_direct_image_url,
     SUPPORTED_PATTERNS,
 )
 from .cookie_manager import get_cookie_file_for_platform
+from .utils import detect_file_type
 
 
 router = APIRouter(prefix="/api", tags=["api"])
-
-
-# ============================================================================
-# File Type Detection (Magic Bytes)
-# ============================================================================
-
-def detect_file_type(data: bytes) -> tuple[str, str]:
-    """
-    Detect file type from magic bytes.
-    Returns (extension, mime_type) or (None, None) if unknown.
-    """
-    if len(data) < 12:
-        return None, None
-
-    # JPEG: FF D8 FF
-    if data[:3] == b'\xff\xd8\xff':
-        return '.jpg', 'image/jpeg'
-
-    # PNG: 89 50 4E 47 0D 0A 1A 0A
-    if data[:8] == b'\x89PNG\r\n\x1a\n':
-        return '.png', 'image/png'
-
-    # GIF: GIF87a or GIF89a
-    if data[:6] in (b'GIF87a', b'GIF89a'):
-        return '.gif', 'image/gif'
-
-    # WebP: RIFF....WEBP
-    if data[:4] == b'RIFF' and data[8:12] == b'WEBP':
-        return '.webp', 'image/webp'
-
-    # HEIC/HEIF/AVIF: ftyp box with brand
-    if data[4:8] == b'ftyp':
-        brand = data[8:12]
-        if brand in (b'heic', b'heix', b'hevc', b'hevx', b'mif1'):
-            return '.heic', 'image/heic'
-        if brand == b'avif':
-            return '.avif', 'image/avif'
-        # MP4/MOV video formats
-        if brand in (b'isom', b'iso2', b'mp41', b'mp42', b'M4V ', b'M4A '):
-            return '.mp4', 'video/mp4'
-        if brand == b'qt  ':
-            return '.mov', 'video/quicktime'
-
-    # BMP: BM
-    if data[:2] == b'BM':
-        return '.bmp', 'image/bmp'
-
-    # TIFF: II or MM
-    if data[:4] in (b'II*\x00', b'MM\x00*'):
-        return '.tiff', 'image/tiff'
-
-    return None, None
 
 
 # ============================================================================
@@ -277,16 +227,17 @@ def create_api_routes(config):
 
         # Validate URL
         platform = identify_platform(url)
-        if not platform:
+        direct_image = is_direct_image_url(url)
+        if not platform and not direct_image:
             raise HTTPException(
                 status_code=400,
-                detail=f"Unsupported URL. Supported platforms: {', '.join(SUPPORTED_PATTERNS.keys())}"
+                detail=f"Unsupported URL. Supported platforms: {', '.join(SUPPORTED_PATTERNS.keys())}. Direct image URLs are also accepted."
             )
 
-        logger.info("URL upload request: platform=%s url=%s", platform, url)
+        logger.info("URL upload request: platform=%s direct_image=%s url=%s", platform, direct_image, url)
 
         # Look up cookies for this platform (if configured)
-        cookies_file = get_cookie_file_for_platform(platform, config.state_db)
+        cookies_file = get_cookie_file_for_platform(platform, config.state_db) if platform else None
 
         # Download the file
         download_result = await download_from_url(url, cookies_file=cookies_file)
@@ -318,16 +269,17 @@ def create_api_routes(config):
                     file_created_at = datetime.fromtimestamp(timestamp).isoformat() + "Z"
 
             # Upload to Immich
+            source_label = platform or "direct_image"
             upload_result = await upload_to_immich(
                 file_content=file_content,
                 filename=download_result.filename,
                 content_type=download_result.content_type,
                 config=config,
                 httpx_client=httpx_client,
-                device_id=f"immich-drop-{platform}",
+                device_id=f"immich-drop-{source_label}",
                 file_created_at=file_created_at,
             )
-            upload_result.platform = platform
+            upload_result.platform = source_label
 
             # Add to album if specified or configured
             album_name = url_request.album_name or getattr(config, 'album_name', None)
@@ -372,26 +324,27 @@ def create_api_routes(config):
                     status_code=400,
                     detail=f"Unsupported URL: {url}"
                 )
-            platforms.append(identify_platform(url))
+            platforms.append(identify_platform(url))  # None for direct image URLs
 
         # Look up cookies - if all URLs are from the same platform, use cookies
         cookies_file = None
-        unique_platforms = set(platforms)
+        unique_platforms = set(p for p in platforms if p is not None)
         if len(unique_platforms) == 1:
-            cookies_file = get_cookie_file_for_platform(platforms[0], config.state_db)
+            cookies_file = get_cookie_file_for_platform(list(unique_platforms)[0], config.state_db)
 
         results = []
         download_results = await download_multiple_urls(urls, cookies_file=cookies_file)
 
         for url, download_result in zip(urls, download_results):
             platform = identify_platform(url)
+            source_label = platform or "direct_image"
 
             if not download_result.success:
                 results.append(UploadResult(
                     filename=url,
                     status="error",
                     error=download_result.error,
-                    platform=platform,
+                    platform=source_label,
                 ))
                 continue
 
@@ -411,10 +364,10 @@ def create_api_routes(config):
                     content_type=download_result.content_type,
                     config=config,
                     httpx_client=httpx_client,
-                    device_id=f"immich-drop-{platform}",
+                    device_id=f"immich-drop-{source_label}",
                     file_created_at=file_created_at,
                 )
-                upload_result.platform = platform
+                upload_result.platform = source_label
 
                 # Add to album
                 album_name = batch_request.album_name or getattr(config, 'album_name', None)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,51 @@
+"""
+Shared utility functions for immich-drop
+"""
+
+
+def detect_file_type(data: bytes) -> tuple[str, str]:
+    """
+    Detect file type from magic bytes.
+    Returns (extension, mime_type) or (None, None) if unknown.
+    """
+    if len(data) < 12:
+        return None, None
+
+    # JPEG: FF D8 FF
+    if data[:3] == b'\xff\xd8\xff':
+        return '.jpg', 'image/jpeg'
+
+    # PNG: 89 50 4E 47 0D 0A 1A 0A
+    if data[:8] == b'\x89PNG\r\n\x1a\n':
+        return '.png', 'image/png'
+
+    # GIF: GIF87a or GIF89a
+    if data[:6] in (b'GIF87a', b'GIF89a'):
+        return '.gif', 'image/gif'
+
+    # WebP: RIFF....WEBP
+    if data[:4] == b'RIFF' and data[8:12] == b'WEBP':
+        return '.webp', 'image/webp'
+
+    # HEIC/HEIF/AVIF: ftyp box with brand
+    if data[4:8] == b'ftyp':
+        brand = data[8:12]
+        if brand in (b'heic', b'heix', b'hevc', b'hevx', b'mif1'):
+            return '.heic', 'image/heic'
+        if brand == b'avif':
+            return '.avif', 'image/avif'
+        # MP4/MOV video formats
+        if brand in (b'isom', b'iso2', b'mp41', b'mp42', b'M4V ', b'M4A '):
+            return '.mp4', 'video/mp4'
+        if brand == b'qt  ':
+            return '.mov', 'video/quicktime'
+
+    # BMP: BM
+    if data[:2] == b'BM':
+        return '.bmp', 'image/bmp'
+
+    # TIFF: II or MM
+    if data[:4] in (b'II*\x00', b'MM\x00*'):
+        return '.tiff', 'image/tiff'
+
+    return None, None

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -33,12 +33,7 @@
   function showBanner(text, kind='ok'){
     if(!banner) return;
     banner.textContent = text;
-    banner.className = 'rounded-2xl p-3 text-center transition-colors ' + (
-      kind==='ok' ? 'border border-green-200 bg-green-50 text-green-700 dark:bg-green-900 dark:border-green-700 dark:text-green-300'
-      : kind==='warn' ? 'border border-amber-200 bg-amber-50 text-amber-700 dark:bg-amber-900 dark:border-amber-700 dark:text-amber-300'
-      : 'border border-red-200 bg-red-50 text-red-700 dark:bg-red-900 dark:border-red-700 dark:text-red-300'
-    );
-    banner.classList.remove('hidden');
+    banner.className = 'banner ' + (kind==='ok' ? 'banner--ok' : kind==='warn' ? 'banner--warn' : 'banner--err');
     setTimeout(() => banner.classList.add('hidden'), 3000);
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,93 +1,73 @@
 <!doctype html>
-<html lang="en" xml:lang="en">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Immich Drop Uploader</title>
+  <title>Immich Drop</title>
   <link rel="icon" type="image/png" href="/static/favicon.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = { darkMode: 'class' };
-  </script>
-  <style> body { padding-bottom: env(safe-area-inset-bottom); } </style>
+  <link rel="stylesheet" href="/static/styles.css" />
 </head>
-<body class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-200">
-  <div class="mx-auto max-w-4xl p-6 space-y-6">
-    <!-- Ephemeral top banner -->
-    <div id="topBanner" class="hidden rounded-2xl border border-green-200 bg-green-50 p-3 text-green-700 text-center dark:bg-green-900 dark:border-green-700 dark:text-green-300"></div>
+<body>
+  <div class="page-wrap page-wrap--wide">
+    <div id="topBanner" class="banner hidden"></div>
 
-    <header class="flex items-center justify-between flex-wrap gap-2">
-      <h1 class="text-2xl font-semibold tracking-tight">Immich Drop Uploader</h1>
-      <div class="flex items-center gap-2">
-        <a href="/login" class="rounded-xl border px-4 py-2 text-sm dark:border-gray-600 dark:hover:bg-gray-800 hover:bg-gray-100 transition-colors" aria-label="Login">Login</a>
-        <button id="btnTheme" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600 dark:hover:bg-gray-800 hover:bg-gray-100 transition-colors" title="Toggle dark mode" aria-label="Toggle theme">
-          <svg id="iconLight" class="w-4 h-4 hidden" fill="currentColor" viewBox="0 0 20 20">
+    <header class="site-header">
+      <h1>Immich Drop</h1>
+      <div class="header-actions">
+        <a href="/login" class="btn">Login</a>
+        <button id="btnTheme" class="btn btn--icon" title="Toggle theme" aria-label="Toggle theme">
+          <svg id="iconLight" class="hidden" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"/>
           </svg>
-          <svg id="iconDark" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <svg id="iconDark" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
           </svg>
         </button>
-        <button id="btnPing" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600 dark:hover:bg-gray-800 hover:bg-gray-100 transition-colors" aria-label="Test connection">Test connection</button>
-        <span id="pingStatus" class="ml-2 text-sm text-gray-500 dark:text-gray-400 hidden sm:inline"></span>
+        <button id="btnPing" class="btn">Test connection</button>
+        <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>
 
     <!-- Dropzone -->
-    <section id="dropzone" class="rounded-2xl border-2 border-dashed p-8 md:p-10 text-center bg-white dark:bg-gray-800 dark:border-gray-600 transition-colors">
-      <div id="dropHint" class="mx-auto h-12 w-12 opacity-70 hidden md:block">
-        <!-- upload icon -->
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 16V8m0 0l-3 3m3-3 3 3M4 16a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4v-1a1 1 0 1 0-2 0v1a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-1a1 1 0 1 0-2 0v1z"/></svg>
+    <section id="dropzone" class="dropzone">
+      <div class="dropzone-desktop">
+        <svg class="dropzone-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 16V8m0 0l-3 3m3-3 3 3M4 16a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4v-1a1 1 0 1 0-2 0v1a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-1a1 1 0 1 0-2 0v1z"/></svg>
+        <p class="dropzone-text">Drop images or videos here</p>
+        <p class="dropzone-sub">...or</p>
       </div>
-      <p class="mt-3 font-medium hidden md:block">Drop images or videos here</p>
-      <p class="text-sm text-gray-600 dark:text-gray-400 hidden md:block">...or</p>
-
-      <!-- Choose files button -->
-      <div class="mt-3 relative inline-block">
-        <label class="rounded-2xl bg-black text-white dark:bg-white dark:text-black px-5 py-3 hover:opacity-90 cursor-pointer select-none transition-colors" aria-label="Choose files">
-          Choose files
-          <input id="fileInput"
-                 type="file"
-                 multiple
-                 accept="image/*,video/*"
-                 class="absolute inset-0 opacity-0 cursor-pointer" />
-        </label>
-      </div>
-
-      <div class="mt-4 text-sm text-gray-500 dark:text-gray-400">
-        We never show uploaded media and keep everything session-local. No account required.
-      </div>
+      <label class="btn btn--primary" style="cursor:pointer;">
+        Choose files
+        <input id="fileInput" type="file" multiple accept="image/*,video/*" class="sr-only" />
+      </label>
+      <p class="dropzone-privacy">We never show uploaded media and keep everything session-local. No account required.</p>
     </section>
 
     <!-- URL Upload section -->
-    <section id="url-upload-section" class="rounded-2xl border bg-white p-6 shadow-sm dark:bg-gray-800 dark:border-gray-700 transition-colors">
-    </section>
+    <section id="url-upload-section" class="card url-section"></section>
 
     <!-- Queue summary -->
-    <section id="summary" class="rounded-2xl border bg-white p-4 shadow-sm dark:bg-gray-800 dark:border-gray-700 transition-colors">
-      <div class="flex flex-wrap items-end justify-between gap-2 text-sm">
-        <!-- Buttons: on small screens show on their own row above -->
-        <div class="order-1 w-full md:order-2 md:w-auto flex gap-2 justify-end">
-          <button id="btnClearFinished" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600 dark:hover:bg-gray-700 hover:bg-gray-100 transition-colors">Clear finished</button>
-          <button id="btnClearAll" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600 dark:hover:bg-gray-700 hover:bg-gray-100 transition-colors">Clear all</button>
+    <section class="card">
+      <div class="stats-bar">
+        <div class="stats-bar__counts">
+          <span>Queued: <b id="countQueued">0</b></span>
+          <span>Uploading: <b id="countUploading">0</b></span>
+          <span>Done: <b id="countDone">0</b></span>
+          <span>Duplicates: <b id="countDup">0</b></span>
+          <span>Errors: <b id="countErr">0</b></span>
         </div>
-        <!-- Counters: wrap cleanly, keep number with its label and align bottoms -->
-        <div class="order-2 w-full md:order-1 md:w-auto flex flex-wrap items-end gap-x-4 gap-y-1">
-          <span class="whitespace-nowrap">Queued/Processing: <b id="countQueued">0</b></span>
-          <span class="whitespace-nowrap">Uploading: <b id="countUploading">0</b></span>
-          <span class="whitespace-nowrap">Done: <b id="countDone">0</b></span>
-          <span class="whitespace-nowrap">Duplicates: <b id="countDup">0</b></span>
-          <span class="whitespace-nowrap">Errors: <b id="countErr">0</b></span>
+        <div class="stats-bar__actions">
+          <button id="btnClearFinished" class="btn btn--sm">Clear finished</button>
+          <button id="btnClearAll" class="btn btn--sm">Clear all</button>
         </div>
       </div>
     </section>
 
     <!-- Items -->
-    <section id="items" class="space-y-3"></section>
+    <section id="items" class="space-y-sm"></section>
 
-    <footer class="pt-4 pb-10 text-center text-xs text-gray-500 dark:text-gray-400 space-y-1">
-      <div>Built for simple, account-less uploads to Immich. This page never lists media from the server and only shows your current session's items.</div>
-      <div><a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener" class="underline hover:text-gray-700 dark:hover:text-gray-300">immich-drop</a></div>
+    <footer class="site-footer">
+      <div>Built for simple, account-less uploads to Immich.</div>
+      <div class="mt-2"><a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener">immich-drop</a></div>
     </footer>
   </div>
 
@@ -96,14 +76,9 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       new UrlUploader('#url-upload-section', {
-        onUploadComplete: (result) => {
-          console.log('URL upload complete:', result);
-        },
-        onError: (error) => {
-          console.error('URL upload error:', error);
-        }
+        onUploadComplete: (result) => { console.log('URL upload complete:', result); },
+        onError: (error) => { console.error('URL upload error:', error); }
       });
-      // Fetch version dynamically
       fetch('/api/config')
         .then(r => r.json())
         .then(data => {

--- a/frontend/invite.html
+++ b/frontend/invite.html
@@ -1,194 +1,166 @@
 <!doctype html>
-<html lang="en" xml:lang="en">
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Immich Drop Uploader (Invite)</title>
+  <title>Immich Drop (Invite)</title>
   <link rel="icon" type="image/png" href="/static/favicon.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = { darkMode: 'class' };
-  </script>
-  <style>
-    body { transition: background-color .2s ease, color .2s ease; padding-bottom: env(safe-area-inset-bottom); }
-  </style>
+  <link rel="stylesheet" href="/static/styles.css" />
   <meta name="robots" content="noindex, nofollow" />
   <meta http-equiv="Cache-Control" content="no-store" />
   <meta http-equiv="Pragma" content="no-cache" />
 </head>
-<body class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-  <div class="mx-auto max-w-4xl p-6 space-y-6">
-    <div id="topBanner" class="hidden rounded-2xl border border-green-200 bg-green-50 p-3 text-green-700 text-center dark:bg-green-900 dark:border-green-700 dark:text-green-300"></div>
+<body>
+  <div class="page-wrap page-wrap--wide">
+    <div id="topBanner" class="banner hidden"></div>
 
-    <header class="flex items-center justify-between flex-wrap gap-2">
-      <h1 class="text-2xl font-semibold tracking-tight">Immich Drop Uploader</h1>
-      <div class="flex items-center gap-2">
-        <a id="linkHome" href="/" class="hidden rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Home</a>
-        <button id="btnTheme" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600" title="Toggle dark mode">
-          <svg id="iconLight" class="w-4 h-4 hidden" fill="currentColor" viewBox="0 0 20 20">
+    <header class="site-header">
+      <h1>Immich Drop</h1>
+      <div class="header-actions">
+        <a id="linkHome" href="/" class="btn hidden">Home</a>
+        <button id="btnTheme" class="btn btn--icon" title="Toggle dark mode" aria-label="Toggle theme">
+          <svg id="iconLight" class="hidden" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414z" clip-rule="evenodd"/>
           </svg>
-          <svg id="iconDark" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <svg id="iconDark" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
           </svg>
         </button>
-        <button id="btnPing" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Test connection</button>
-        <span id="pingStatus" class="ml-2 text-sm text-gray-500 dark:text-gray-400"></span>
+        <button id="btnPing" class="btn">Test connection</button>
+        <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>
 
-    <!-- Link information -->
-    <section id="linkInfo" class="rounded-2xl border bg-white dark:bg-gray-800 dark:border-gray-700 p-4 text-sm">
-      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+    <!-- Link info -->
+    <section id="linkInfo" class="card">
+      <div class="form-row form-row--2" style="font-size:0.8125rem;">
         <div>
-          <div><b>Status:</b> <span id="liStatus">Loading…</span></div>
-          <div><b>Album:</b> <span id="liAlbum">—</span></div>
+          <div><b>Status:</b> <span id="liStatus">Loading...</span></div>
+          <div><b>Album:</b> <span id="liAlbum">--</span></div>
         </div>
-        <div class="grid grid-cols-2 gap-x-6 gap-y-1">
-          <div><b>Type:</b> <span id="liType">—</span></div>
-          <div><b>Uses left:</b> <span id="liUses">—</span></div>
-          <div><b>Expires:</b> <span id="liExpires">—</span></div>
-          <div><b>Claimed:</b> <span id="liClaimed">—</span></div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Password gate (hidden unless required) -->
-    <section id="pwGate" class="hidden rounded-2xl border bg-white dark:bg-gray-800 dark:border-gray-700 p-4 space-y-3">
-      <div class="text-sm">This link is protected. Enter the password to continue.</div>
-      <div class="flex flex-col sm:flex-row gap-2">
-        <input id="pwInput" type="password" placeholder="Password" class="flex-1 rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700" />
-        <button id="btnPw" class="rounded-xl bg-black text-white px-4 py-3 dark:bg-white dark:text-black">Unlock</button>
-      </div>
-      <div id="pwError" class="hidden text-sm text-red-600 dark:text-red-400"></div>
-    </section>
-
-    <!-- Dropzone and queue copied from index.html -->
-    <section id="dropzone" class="rounded-2xl border-2 border-dashed p-8 md:p-10 text-center bg-white dark:bg-gray-800 dark:border-gray-600">
-      <div id="dropHint" class="mx-auto h-12 w-12 opacity-70 hidden md:block">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 16V8m0 0l-3 3m3-3 3 3M4 16a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4v-1a1 1 0 1 0-2 0v1a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-1a1 1 0 1 0-2 0v1z"/></svg>
-      </div>
-      <p class="mt-3 font-medium hidden md:block">Drop images or videos here</p>
-      <p class="text-sm text-gray-600 dark:text-gray-400 hidden md:block">...or</p>
-      <!-- Choose files button -->
-      <div class="mt-3 relative inline-block">
-        <label class="rounded-2xl bg-black text-white dark:bg-white dark:text-black px-5 py-3 hover:opacity-90 cursor-pointer select-none" aria-label="Choose files">
-          Choose files
-          <input id="fileInput" type="file" multiple accept="image/*,video/*" class="absolute inset-0 opacity-0 cursor-pointer" />
-        </label>
-      </div>
-      <div class="mt-4 text-sm text-gray-500 dark:text-gray-400">
-        Files will be uploaded to the selected album for this invite.
-      </div>
-    </section>
-
-    <section id="summary" class="rounded-2xl border bg-white p-4 shadow-sm dark:bg-gray-800 dark:border-gray-700">
-      <div class="flex flex-wrap items-end justify-between gap-2 text-sm">
-        <!-- Buttons: ensure present on invite page and visible on small screens -->
-        <div class="order-1 w-full md:order-2 md:w-auto flex gap-2 justify-end">
-          <button id="btnClearFinished" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600 dark:hover:bg-gray-700 hover:bg-gray-100 transition-colors">Clear finished</button>
-          <button id="btnClearAll" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600 dark:hover:bg-gray-700 hover:bg-gray-100 transition-colors">Clear all</button>
-        </div>
-        <!-- Counters: wrap cleanly, keep number with its label and align bottoms -->
-        <div class="order-2 w-full md:order-1 md:w-auto flex flex-wrap items-end gap-x-4 gap-y-1">
-          <span class="whitespace-nowrap">Queued/Processing: <b id="countQueued">0</b></span>
-          <span class="whitespace-nowrap">Uploading: <b id="countUploading">0</b></span>
-          <span class="whitespace-nowrap">Done: <b id="countDone">0</b></span>
-          <span class="whitespace-nowrap">Duplicates: <b id="countDup">0</b></span>
-          <span class="whitespace-nowrap">Errors: <b id="countErr">0</b></span>
+        <div>
+          <div><b>Type:</b> <span id="liType">--</span></div>
+          <div><b>Uses left:</b> <span id="liUses">--</span></div>
+          <div><b>Expires:</b> <span id="liExpires">--</span></div>
         </div>
       </div>
     </section>
 
-    <section id="items" class="space-y-3"></section>
-    <footer class="pt-4 pb-10 text-center text-xs text-gray-500 dark:text-gray-400 space-y-1">
+    <!-- Password gate -->
+    <section id="pwGate" class="card hidden">
+      <p class="text-sm text-secondary mb-3">This link is protected. Enter the password to continue.</p>
+      <div class="flex gap-2" style="flex-wrap:wrap;">
+        <input id="pwInput" type="password" placeholder="Password" class="input flex-1" />
+        <button id="btnPw" class="btn btn--primary">Unlock</button>
+      </div>
+      <div id="pwError" class="banner banner--err hidden mt-2"></div>
+    </section>
+
+    <!-- Dropzone -->
+    <section id="dropzone" class="dropzone">
+      <div class="dropzone-desktop">
+        <svg class="dropzone-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 16V8m0 0l-3 3m3-3 3 3M4 16a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4v-1a1 1 0 1 0-2 0v1a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2v-1a1 1 0 1 0-2 0v1z"/></svg>
+        <p class="dropzone-text">Drop images or videos here</p>
+        <p class="dropzone-sub">...or</p>
+      </div>
+      <label class="btn btn--primary" style="cursor:pointer;">
+        Choose files
+        <input id="fileInput" type="file" multiple accept="image/*,video/*" class="sr-only" />
+      </label>
+      <p class="dropzone-privacy">Files will be uploaded to the selected album for this invite.</p>
+    </section>
+
+    <!-- Queue summary -->
+    <section class="card">
+      <div class="stats-bar">
+        <div class="stats-bar__counts">
+          <span>Queued: <b id="countQueued">0</b></span>
+          <span>Uploading: <b id="countUploading">0</b></span>
+          <span>Done: <b id="countDone">0</b></span>
+          <span>Duplicates: <b id="countDup">0</b></span>
+          <span>Errors: <b id="countErr">0</b></span>
+        </div>
+        <div class="stats-bar__actions">
+          <button id="btnClearFinished" class="btn btn--sm">Clear finished</button>
+          <button id="btnClearAll" class="btn btn--sm">Clear all</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="items" class="space-y-sm"></section>
+
+    <footer class="site-footer">
       <div>Invite upload page</div>
-      <div><a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener" class="underline hover:text-gray-700 dark:hover:text-gray-300">immich-drop</a></div>
+      <div class="mt-2"><a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener">immich-drop</a></div>
     </footer>
   </div>
+
   <script src="/static/header.js"></script>
   <script src="/static/app.js"></script>
-</body>
-<script>
-  // Hide ping and theme controls if referenced by app.js
-  // Standardized header includes ping + theme; no-op guards in app.js
-  // Populate link info section
-  (async function(){
-    try {
-      const parts = (location.pathname || '').split('/').filter(Boolean);
-      const token = parts[1];
-      const r = await fetch(`/api/invite/${token}`);
-      const j = await r.json();
-      const fmt = (s)=> s ? new Date(s).toLocaleString() : '—';
-      document.getElementById('liAlbum').textContent = j.albumName || j.albumId || '—';
-      document.getElementById('liType').textContent = j.oneTime ? 'One-time' : (j.maxUses < 0 ? 'Indefinite' : `Up to ${j.maxUses} uses`);
-      document.getElementById('liUses').textContent = (typeof j.remaining==='number') ? String(j.remaining) : '—';
-      document.getElementById('liExpires').textContent = j.expiresAt ? fmt(j.expiresAt) : 'No expiry';
-      document.getElementById('liClaimed').textContent = j.claimed ? 'Yes' : 'No';
-      document.getElementById('liStatus').textContent = j.active ? 'Active' : ('Inactive' + (j.inactiveReason ? (' ('+j.inactiveReason+')') : ''));
-      const dz = document.getElementById('dropzone');
-      const fi = document.getElementById('fileInput');
-      const itemsEl = document.getElementById('items');
-      const pwGate = document.getElementById('pwGate');
-      if (j.passwordRequired && !j.authorized) {
-        // Show password gate and disable uploader until authorized
-        pwGate.classList.remove('hidden');
-        dz.classList.add('opacity-50');
-        if (fi) fi.disabled = true;
-        itemsEl.innerHTML = '<div class="text-sm text-gray-500">Enter the password above to enable uploads.</div>';
-        // Wire unlock button
-        const pwInput = document.getElementById('pwInput');
-        const btnPw = document.getElementById('btnPw');
-        const pwError = document.getElementById('pwError');
-        const doAuth = async () => {
-          pwError.classList.add('hidden');
-          const pw = (pwInput && pwInput.value) ? pwInput.value.trim() : '';
-          if (!pw) { pwError.textContent = 'Please enter a password.'; pwError.classList.remove('hidden'); return; }
-          try {
-            const rr = await fetch(`/api/invite/${token}/auth`, { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ password: pw }) });
-            const jj = await rr.json().catch(()=>({}));
-            if (!rr.ok || !jj.authorized) { pwError.textContent = 'Invalid password.'; pwError.classList.remove('hidden'); return; }
-            pwGate.classList.add('hidden');
-            dz.classList.remove('opacity-50');
-            if (fi) fi.disabled = false;
-            itemsEl.innerHTML = '';
-            try { showBanner('Password accepted. You can upload now.', 'ok'); } catch {}
-          } catch (e) {
-            pwError.textContent = 'Error verifying password.';
-            pwError.classList.remove('hidden');
-          }
-        };
-        if (btnPw) btnPw.onclick = doAuth;
-        if (pwInput) pwInput.addEventListener('keydown', (e)=>{ if (e.key==='Enter') { e.preventDefault(); doAuth(); } });
-      }
-      if (!j.active) {
-        // Disable dropzone
-        dz.classList.add('opacity-50');
-        fi.disabled = true;
-        itemsEl.innerHTML = `<div class="text-sm text-gray-500">This link is not active${j.inactiveReason?` (${j.inactiveReason})`:''}.</div>`;
-      }
-    } catch {}
-  })();
-  // Hook theme/ping
-  (function(){
-    const btnTheme = document.getElementById('btnTheme');
-    const btnPing = document.getElementById('btnPing');
-    const pingStatus = document.getElementById('pingStatus');
-    if (btnTheme) btnTheme.onclick = ()=>{ const isDark = document.documentElement.classList.toggle('dark'); try{ localStorage.setItem('theme', isDark ? 'dark':'light'); }catch{}; const isDarkNow = document.documentElement.classList.contains('dark'); try{ document.getElementById('iconLight').classList.toggle('hidden', !isDarkNow); document.getElementById('iconDark').classList.toggle('hidden', isDarkNow);}catch{} };
-    if (btnPing) btnPing.onclick = async ()=>{
-      pingStatus.textContent = 'checking…';
-      try { const r = await fetch('/api/ping', { method:'POST' }); const j = await r.json(); pingStatus.textContent = j.ok ? 'Connected' : 'No connection'; pingStatus.className = 'ml-2 text-sm ' + (j.ok ? 'text-green-600' : 'text-red-600'); if(j.ok){ let text = `Connected to Immich at ${j.base_url}`; if(j.album_name) text += ` | Uploading to album: "${j.album_name}"`; showBanner(text, 'ok'); } } catch { pingStatus.textContent = 'No connection'; pingStatus.className='ml-2 text-sm text-red-600'; }
-    };
-    // Fetch version dynamically
-    fetch('/api/config')
-      .then(r => r.json())
-      .then(data => {
-        const versionEl = document.getElementById('version-link');
-        if (versionEl && data.version) {
-          versionEl.textContent = 'immich-drop v' + data.version;
+  <script>
+    (async function(){
+      try {
+        var parts = (location.pathname || '').split('/').filter(Boolean);
+        var token = parts[1];
+        var r = await fetch('/api/invite/'+token);
+        var j = await r.json();
+        var fmt = function(s){ return s ? new Date(s).toLocaleString() : '--'; };
+        document.getElementById('liAlbum').textContent = j.albumName || j.albumId || '--';
+        document.getElementById('liType').textContent = j.oneTime ? 'One-time' : (j.maxUses < 0 ? 'Indefinite' : 'Up to '+j.maxUses+' uses');
+        document.getElementById('liUses').textContent = (typeof j.remaining==='number') ? String(j.remaining) : '--';
+        document.getElementById('liExpires').textContent = j.expiresAt ? fmt(j.expiresAt) : 'No expiry';
+        document.getElementById('liStatus').textContent = j.active ? 'Active' : ('Inactive' + (j.inactiveReason ? (' ('+j.inactiveReason+')') : ''));
+        var dz = document.getElementById('dropzone');
+        var fi = document.getElementById('fileInput');
+        var itemsEl = document.getElementById('items');
+        var pwGate = document.getElementById('pwGate');
+        if (j.passwordRequired && !j.authorized) {
+          pwGate.classList.remove('hidden');
+          dz.style.opacity = '0.5';
+          if (fi) fi.disabled = true;
+          itemsEl.textContent = 'Enter the password above to enable uploads.';
+          itemsEl.className = 'text-sm text-secondary';
+          var pwInput = document.getElementById('pwInput');
+          var btnPw = document.getElementById('btnPw');
+          var pwError = document.getElementById('pwError');
+          var doAuth = async function(){
+            pwError.classList.add('hidden');
+            var pw = (pwInput && pwInput.value) ? pwInput.value.trim() : '';
+            if (!pw) { pwError.textContent = 'Please enter a password.'; pwError.classList.remove('hidden'); return; }
+            try {
+              var rr = await fetch('/api/invite/'+token+'/auth', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ password: pw }) });
+              var jj = await rr.json().catch(function(){ return {}; });
+              if (!rr.ok || !jj.authorized) { pwError.textContent = 'Invalid password.'; pwError.classList.remove('hidden'); return; }
+              pwGate.classList.add('hidden');
+              dz.style.opacity = '1';
+              if (fi) fi.disabled = false;
+              itemsEl.textContent = '';
+              itemsEl.className = 'space-y-sm';
+              try { window.__header.showBanner('Password accepted. You can upload now.', 'ok'); } catch(e2){}
+            } catch (e) {
+              pwError.textContent = 'Error verifying password.';
+              pwError.classList.remove('hidden');
+            }
+          };
+          if (btnPw) btnPw.onclick = doAuth;
+          if (pwInput) pwInput.addEventListener('keydown', function(e){ if (e.key==='Enter') { e.preventDefault(); doAuth(); } });
         }
+        if (!j.active) {
+          dz.style.opacity = '0.5';
+          fi.disabled = true;
+          itemsEl.textContent = 'This link is not active'+(j.inactiveReason?' ('+j.inactiveReason+')':'')+'.';
+          itemsEl.className = 'text-sm text-secondary';
+        }
+      } catch(e){}
+    })();
+    // Fetch version
+    fetch('/api/config')
+      .then(function(r){ return r.json(); })
+      .then(function(data){
+        var versionEl = document.getElementById('version-link');
+        if (versionEl && data.version) versionEl.textContent = 'immich-drop v' + data.version;
       })
-      .catch(() => {});
-  })();
-</script>
+      .catch(function(){});
+  </script>
+</body>
 </html>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -3,62 +3,62 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Login – Immich Drop</title>
+  <title>Login - Immich Drop</title>
   <link rel="icon" type="image/png" href="/static/favicon.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = { darkMode: 'class' };
-  </script>
+  <link rel="stylesheet" href="/static/styles.css" />
 </head>
-<body class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-  <div class="mx-auto max-w-2xl p-6 space-y-6">
-    <div id="topBanner" class="hidden rounded-2xl border border-green-200 bg-green-50 p-3 text-green-700 text-center dark:bg-green-900 dark:border-green-700 dark:text-green-300"></div>
-    <header class="flex items-center justify-between">
-      <h1 class="text-2xl font-semibold">Login to Immich</h1>
-      <div class="flex items-center gap-2">
-        <a id="linkPublicUploader" href="/" class="hidden rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Public uploader</a>
-        <button id="btnTheme" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600" title="Toggle dark mode">
-          <svg id="iconLight" class="w-4 h-4 hidden" fill="currentColor" viewBox="0 0 20 20">
+<body>
+  <div class="page-wrap" style="max-width:440px;">
+    <div id="topBanner" class="banner hidden"></div>
+
+    <header class="site-header">
+      <h1>Login</h1>
+      <div class="header-actions">
+        <a id="linkPublicUploader" href="/" class="btn hidden">Public uploader</a>
+        <button id="btnTheme" class="btn btn--icon" title="Toggle dark mode" aria-label="Toggle theme">
+          <svg id="iconLight" class="hidden" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414z" clip-rule="evenodd"/>
           </svg>
-          <svg id="iconDark" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <svg id="iconDark" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
           </svg>
         </button>
-        <button id="btnPing" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Test connection</button>
-        <span id="pingStatus" class="ml-2 text-sm text-gray-500 dark:text-gray-400"></span>
+        <button id="btnPing" class="btn">Test connection</button>
+        <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>
-    <div class="max-w-md">
-    <h2 class="text-lg font-medium mb-2">Enter your credentials</h2>
-    <div id="msg" class="hidden mb-3 rounded-lg border p-2 text-sm"></div>
-    <form id="loginForm" class="space-y-3">
-      <div>
-        <label class="block text-sm mb-1">Email</label>
-        <input id="email" type="email" required class="w-full rounded-lg border px-3 py-2 bg-white dark:bg-gray-800 dark:border-gray-700" />
-      </div>
-      <div>
-        <label class="block text-sm mb-1">Password</label>
-        <input id="password" type="password" required class="w-full rounded-lg border px-3 py-2 bg-white dark:bg-gray-800 dark:border-gray-700" />
-      </div>
-      <div class="flex items-center justify-between">
-        <button class="rounded-xl bg-black text-white px-4 py-2 dark:bg-white dark:text-black" type="submit">Login</button>
-        <a href="/" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600 dark:hover:bg-gray-800 hover:bg-gray-100 transition-colors">Back to uploader</a>
-      </div>
-    </form>
+
+    <div class="card">
+      <h2 style="font-size:1rem;font-weight:600;margin-bottom:16px;">Sign in to your Immich account</h2>
+      <div id="msg" class="banner hidden mb-3"></div>
+      <form id="loginForm" autocomplete="on">
+        <div class="form-group">
+          <label class="form-label" for="email">Email</label>
+          <input id="email" type="email" required class="input" autocomplete="email" />
+        </div>
+        <div class="form-group">
+          <label class="form-label" for="password">Password</label>
+          <input id="password" type="password" required class="input" autocomplete="current-password" />
+        </div>
+        <div class="flex items-center justify-between gap-2 mt-4">
+          <button class="btn btn--primary" type="submit">Login</button>
+          <a href="/" class="btn">Back to uploader</a>
+        </div>
+      </form>
     </div>
-    <footer class="pt-8 pb-10 text-center text-xs text-gray-500 dark:text-gray-400 space-y-1">
-      <div><a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener" class="underline hover:text-gray-700 dark:hover:text-gray-300">immich-drop</a></div>
+
+    <footer class="site-footer">
+      <a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener">immich-drop</a>
     </footer>
   </div>
+
   <script src="/static/header.js"></script>
   <script>
     const form = document.getElementById('loginForm');
     const msg = document.getElementById('msg');
     function show(kind, text){
       msg.textContent = text;
-      msg.className = 'mb-3 rounded-lg border p-2 text-sm ' + (kind==='ok' ? 'border-green-200 bg-green-50 text-green-700 dark:bg-green-900 dark:border-green-700 dark:text-green-300' : 'border-red-200 bg-red-50 text-red-700 dark:bg-red-900 dark:border-red-700 dark:text-red-300');
-      msg.classList.remove('hidden');
+      msg.className = 'banner mb-3 ' + (kind==='ok' ? 'banner--ok' : 'banner--err');
     }
     form.onsubmit = async (e)=>{
       e.preventDefault();
@@ -68,12 +68,10 @@
         const r = await fetch('/api/login', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({email, password}) });
         const j = await r.json().catch(()=>({}));
         if(!r.ok){ show('err', j.error || 'Login failed'); return; }
-        show('ok', 'Login successful. Redirecting…');
+        show('ok', 'Login successful. Redirecting...');
         setTimeout(()=>{ location.href = '/menu'; }, 500);
       }catch(err){ show('err', String(err)); }
     };
-    // header.js wires theme + ping and provides consistent banner behavior
-    // Fetch version dynamically
     fetch('/api/config')
       .then(r => r.json())
       .then(data => {

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -3,649 +3,104 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Menu – Immich Drop</title>
+  <title>Admin - Immich Drop</title>
   <link rel="icon" type="image/png" href="/static/favicon.png" />
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = { darkMode: 'class' };
-  </script>
+  <link rel="stylesheet" href="/static/styles.css" />
 </head>
-<body class="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-  <div class="mx-auto max-w-2xl p-6 space-y-6">
-    <div id="topBanner" class="hidden rounded-2xl border border-green-200 bg-green-50 p-3 text-green-700 text-center dark:bg-green-900 dark:border-green-700 dark:text-green-300"></div>
-    <header class="flex items-center justify-between">
-      <h1 class="text-2xl font-semibold">Create Upload Link</h1>
-      <div class="flex items-center gap-2">
-        <a id="linkPublicUploader" href="/" class="hidden rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Public uploader</a>
-        <a href="/logout" id="btnLogout" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Logout</a>
-        <button id="btnTheme" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600" title="Toggle dark mode">
-          <svg id="iconLight" class="w-4 h-4 hidden" fill="currentColor" viewBox="0 0 20 20">
+<body>
+  <div class="page-wrap page-wrap--wide">
+    <div id="topBanner" class="banner hidden"></div>
+
+    <header class="site-header">
+      <h1>Admin</h1>
+      <div class="header-actions">
+        <a id="linkPublicUploader" href="/" class="btn hidden">Public uploader</a>
+        <a href="/logout" id="btnLogout" class="btn">Logout</a>
+        <button id="btnTheme" class="btn btn--icon" title="Toggle dark mode" aria-label="Toggle theme">
+          <svg id="iconLight" class="hidden" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414z" clip-rule="evenodd"/>
           </svg>
-          <svg id="iconDark" class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+          <svg id="iconDark" fill="currentColor" viewBox="0 0 20 20" width="16" height="16">
             <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"/>
           </svg>
         </button>
-        <button id="btnPing" class="rounded-xl border px-3 py-1 text-sm dark:border-gray-600">Test connection</button>
-        <span id="pingStatus" class="ml-2 text-sm text-gray-500 dark:text-gray-400"></span>
+        <button id="btnPing" class="btn">Test connection</button>
+        <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>
 
-    <section class="rounded-2xl border bg-white dark:bg-gray-800 dark:border-gray-700 p-4 space-y-4">
-      <div>
-        <div class="text-sm font-medium mb-1">Target album (optional)</div>
-        <div id="albumControls" class="space-y-2">
-          <div id="albumSelectWrap" class="hidden">
-            <select id="albumSelect" class="w-full rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700"></select>
-          </div>
+    <!-- Create Upload Link -->
+    <section class="card">
+      <div class="card-header"><h2>Create Upload Link</h2></div>
+      <div class="form-group">
+        <label class="form-label">Target album (optional)</label>
+        <div id="albumControls" class="space-y-sm">
+          <div id="albumSelectWrap" class="hidden"><select id="albumSelect" class="input"></select></div>
           <div id="albumInputWrap" class="hidden">
-            <input id="albumInput" placeholder="Album name (leave blank for none)" class="w-full rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700" />
-            <button id="btnCreateAlbum" class="mt-2 w-full sm:w-auto rounded-xl border px-4 py-3 dark:border-gray-600 dark:hover:bg-gray-800 hover:bg-gray-100 transition-colors">Create album</button>
+            <input id="albumInput" placeholder="Album name (leave blank for none)" class="input" />
+            <button id="btnCreateAlbum" class="btn mt-2">Create album</button>
           </div>
-          <div id="albumHint" class="text-sm text-gray-500"></div>
+          <div id="albumHint" class="form-hint"></div>
         </div>
       </div>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div>
-          <div class="text-sm font-medium mb-1">Usage</div>
-          <select id="usage" class="w-full rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700">
-            <option value="1">One-time</option>
-            <option value="-1">Indefinite</option>
-          </select>
-        </div>
-        <div>
-          <div class="text-sm font-medium mb-1">Expires in days</div>
-          <input id="days" type="number" min="0" placeholder="Leave empty for no expiry" class="w-full rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700" />
-        </div>
-        <div>
-          <div class="text-sm font-medium mb-1">Password (optional)</div>
-          <input id="password" type="password" placeholder="Set a password for this link" class="w-full rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700" />
-          <div class="mt-1 text-xs text-gray-500">Recipients must enter this password before uploading.</div>
-        </div>
+      <div class="form-row form-row--3">
+        <div><label class="form-label">Usage</label><select id="usage" class="input"><option value="1">One-time</option><option value="-1">Indefinite</option></select></div>
+        <div><label class="form-label">Expires in days</label><input id="days" type="number" min="0" placeholder="No expiry" class="input" /></div>
+        <div><label class="form-label">Password (optional)</label><input id="password" type="password" placeholder="Set a password" class="input" autocomplete="off" /><div class="form-hint">Recipients must enter this before uploading.</div></div>
       </div>
-      <div>
-        <button id="btnCreate" class="w-full sm:w-auto rounded-xl bg-black text-white px-5 py-3 dark:bg-white dark:text-black">Create link</button>
-      </div>
-      <div id="result" class="hidden rounded-xl border p-3 text-sm space-y-2">
-        <div id="linkRow" class="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
-          <input id="linkOut" class="flex-1 rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700" readonly />
-          <button id="btnCopy" type="button" class="rounded-xl border px-4 py-3 text-sm dark:border-gray-600" aria-label="Copy link">Copy</button>
-        </div>
-        <div>
-          <img id="qrImg" alt="QR" class="h-32 w-32 md:h-40 md:w-40" />
-        </div>
+      <div class="mt-3"><button id="btnCreate" class="btn btn--primary">Create link</button></div>
+      <div id="result" class="hidden mt-3">
+        <div id="linkRow" class="flex gap-2" style="flex-wrap:wrap;"><input id="linkOut" class="input flex-1" readonly /><button id="btnCopy" type="button" class="btn">Copy</button></div>
+        <div class="mt-2"><img id="qrImg" alt="QR" style="width:140px;height:140px;" /></div>
       </div>
     </section>
 
-    <!-- Manage links -->
-    <section class="rounded-2xl border bg-white dark:bg-gray-800 dark:border-gray-700 p-4 space-y-3">
-      <div class="flex items-center justify-between gap-2 flex-wrap">
-        <h2 class="text-lg font-medium">Manage Links</h2>
-        <div class="flex items-center gap-2">
-          <input id="searchQ" placeholder="Search" class="rounded-lg border px-3 py-2 bg-white dark:bg-gray-900 dark:border-gray-700"/>
-          <select id="sortSel" class="rounded-lg border px-3 py-2 bg-white dark:bg-gray-900 dark:border-gray-700">
-            <option value="-created">Newest</option>
-            <option value="created">Oldest</option>
-            <option value="-expires">Expiry desc</option>
-            <option value="expires">Expiry asc</option>
-            <option value="name">Name A–Z</option>
-            <option value="-name">Name Z–A</option>
-          </select>
-          <button id="btnRefresh" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600">Refresh</button>
+    <!-- Manage Links -->
+    <section class="card">
+      <div class="card-header">
+        <h2>Manage Links</h2>
+        <div class="flex gap-2 flex-wrap items-center">
+          <input id="searchQ" placeholder="Search..." class="input" style="width:140px;" />
+          <select id="sortSel" class="input" style="width:130px;"><option value="-created">Newest</option><option value="created">Oldest</option><option value="-expires">Expiry desc</option><option value="expires">Expiry asc</option><option value="name">Name A-Z</option><option value="-name">Name Z-A</option></select>
+          <button id="btnRefresh" class="btn btn--sm">Refresh</button>
         </div>
       </div>
-      <div class="overflow-x-auto">
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="text-left border-b dark:border-gray-700">
-              <th class="py-2"><input id="chkAll" type="checkbox"/></th>
-              <th class="py-2" style="width: 45%;">Name</th>
-              <th class="py-2" style="width: 18%;">Status</th>
-              <th class="py-2">Uses</th>
-              <th class="py-2">Expires</th>
-              <th class="py-2">Album</th>
-              <th class="py-2">Actions</th>
-            </tr>
-          </thead>
+      <div style="overflow-x:auto;">
+        <table class="data-table data-table--responsive">
+          <thead><tr><th style="width:32px;"><input id="chkAll" type="checkbox"/></th><th>Name</th><th>Status</th><th>Uses</th><th>Expires</th><th>Album</th><th>Actions</th></tr></thead>
           <tbody id="invitesTBody"></tbody>
         </table>
       </div>
-      <!-- Footer inside the panel to keep bulk actions within the box -->
-      <div class="pt-3 mt-2 border-t dark:border-gray-700 flex items-center justify-end gap-2 flex-wrap">
-        <button id="btnDisableSel" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600">Disable selected</button>
-        <button id="btnEnableSel" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600">Enable selected</button>
-        <button id="btnDeleteSel" class="rounded-xl border px-3 py-2 text-sm border-red-400 text-red-600 dark:border-red-600">Delete selected</button>
+      <div class="flex justify-end gap-2 flex-wrap mt-3" style="padding-top:12px;border-top:1px solid var(--border);">
+        <button id="btnDisableSel" class="btn btn--sm">Disable selected</button>
+        <button id="btnEnableSel" class="btn btn--sm">Enable selected</button>
+        <button id="btnDeleteSel" class="btn btn--sm btn--danger">Delete selected</button>
       </div>
     </section>
 
-    <!-- Platform Cookies for authenticated downloads -->
-    <section class="rounded-2xl border bg-white dark:bg-gray-800 dark:border-gray-700 p-4 space-y-3">
-      <div class="flex items-center justify-between gap-2 flex-wrap">
-        <h2 class="text-lg font-medium">Platform Cookies</h2>
-        <button id="btnRefreshCookies" class="rounded-xl border px-3 py-2 text-sm dark:border-gray-600">Refresh</button>
+    <!-- Platform Cookies -->
+    <section class="card">
+      <div class="card-header"><h2>Platform Cookies</h2><button id="btnRefreshCookies" class="btn btn--sm">Refresh</button></div>
+      <p class="text-sm text-secondary mb-3">Add cookies for authenticated social media downloads. Paste the raw cookie header from your browser DevTools (Network tab).</p>
+      <div class="form-row" style="grid-template-columns:160px 1fr auto;align-items:end;">
+        <div><label class="form-label">Platform</label><select id="cookiePlatform" class="input"><option value="">Select...</option></select></div>
+        <div><label class="form-label">Cookie String</label><textarea id="cookieString" rows="2" placeholder="sessionid=abc123; csrftoken=xyz789; ..." class="input" style="font-family:var(--font-mono);font-size:0.8125rem;"></textarea></div>
+        <div><button id="btnSaveCookie" class="btn btn--primary">Save</button></div>
       </div>
-      <p class="text-sm text-gray-500 dark:text-gray-400">
-        Add cookies for authenticated downloads from social media platforms.
-        Paste the raw cookie header from your browser's developer tools (Network tab > Request Headers > Cookie).
-      </p>
-      <div class="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
-        <div>
-          <div class="text-sm font-medium mb-1">Platform</div>
-          <select id="cookiePlatform" class="w-full rounded-lg border px-3 py-3 bg-white dark:bg-gray-900 dark:border-gray-700">
-            <option value="">Select platform...</option>
-          </select>
-        </div>
-        <div class="md:col-span-2">
-          <div class="text-sm font-medium mb-1">Cookie String</div>
-          <textarea id="cookieString" rows="2" placeholder="sessionid=abc123; csrftoken=xyz789; ..." class="w-full rounded-lg border px-3 py-2 bg-white dark:bg-gray-900 dark:border-gray-700 text-sm font-mono"></textarea>
-        </div>
-        <div>
-          <button id="btnSaveCookie" class="w-full rounded-xl bg-black text-white px-4 py-3 dark:bg-white dark:text-black">Save Cookie</button>
-        </div>
-      </div>
-      <div id="cookieResult" class="hidden rounded-xl border p-3 text-sm"></div>
-      <div class="overflow-x-auto">
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="text-left border-b dark:border-gray-700">
-              <th class="py-2">Platform</th>
-              <th class="py-2">Cookie Preview</th>
-              <th class="py-2">Updated</th>
-              <th class="py-2">Actions</th>
-            </tr>
-          </thead>
+      <div id="cookieResult" class="banner hidden mt-3"></div>
+      <div style="overflow-x:auto;" class="mt-3">
+        <table class="data-table data-table--responsive">
+          <thead><tr><th>Platform</th><th>Cookie Preview</th><th>Updated</th><th>Actions</th></tr></thead>
           <tbody id="cookiesTBody"></tbody>
         </table>
       </div>
     </section>
 
-    <section class="text-xs text-gray-500">
-      If album listing or creation is forbidden by your token, specify a fixed album in the .env file as IMMICH_ALBUM_NAME.
-    </section>
-
-    <footer class="pt-4 pb-6 text-center text-xs text-gray-500 dark:text-gray-400">
-      <a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener" class="underline hover:text-gray-700 dark:hover:text-gray-300">immich-drop</a>
-    </footer>
+    <div class="text-xs text-tertiary" style="margin-bottom:12px;">If album listing or creation is forbidden by your token, specify a fixed album in the .env file as IMMICH_ALBUM_NAME.</div>
+    <footer class="site-footer"><a id="version-link" href="https://github.com/ttlequals0/immich-drop" target="_blank" rel="noopener">immich-drop</a></footer>
   </div>
 
   <script src="/static/header.js"></script>
-  <script>
-    const albumSelectWrap = document.getElementById('albumSelectWrap');
-    const albumSelect = document.getElementById('albumSelect');
-    const albumInputWrap = document.getElementById('albumInputWrap');
-    const albumInput = document.getElementById('albumInput');
-    const albumHint = document.getElementById('albumHint');
-    const btnCreateAlbum = document.getElementById('btnCreateAlbum');
-    const btnCreate = document.getElementById('btnCreate');
-    const usage = document.getElementById('usage');
-    const days = document.getElementById('days');
-    const result = document.getElementById('result');
-    const btnLogout = document.getElementById('btnLogout');
-    const btnTheme = document.getElementById('btnTheme');
-    const btnPing = document.getElementById('btnPing');
-    const pingStatus = document.getElementById('pingStatus');
-    const linkOut = document.getElementById('linkOut');
-    const btnCopy = document.getElementById('btnCopy');
-    const qrImg = document.getElementById('qrImg');
-    const passwordInput = document.getElementById('password');
-
-    function showResult(kind, text){
-      result.className = 'rounded-xl border p-3 text-sm space-y-2 ' + (kind==='ok' ? 'border-green-200 bg-green-50 text-green-700 dark:bg-green-900 dark:border-green-700 dark:text-green-300' : 'border-red-200 bg-red-50 text-red-700 dark:bg-red-900 dark:border-red-700 dark:text-red-300');
-      result.classList.remove('hidden');
-    }
-
-    async function loadAlbums(){
-      try {
-        const r = await fetch('/api/albums');
-        if (r.status === 403) {
-          albumHint.textContent = 'Listing albums is forbidden with current credentials. You can still type a new album name or leave it blank to upload without an album. If IMMICH_ALBUM_NAME is set in .env, that will be used for non-invite uploads.';
-          albumInputWrap.classList.remove('hidden');
-          return;
-        }
-        const list = await r.json();
-        if (Array.isArray(list)){
-          const opts = [{id:'', name:'— No album —'}].concat(list.map(a => ({id:a.id, name:(a.albumName || a.title || a.id)})));
-          albumSelect.innerHTML = opts.map(a => `<option value="${a.id}">${a.name}</option>`).join('');
-          albumSelectWrap.classList.remove('hidden');
-          albumInputWrap.classList.remove('hidden');
-          albumHint.textContent = 'Pick an existing album, or type a new name and click Create album. Select “— No album —” or leave the field blank to skip album association.';
-        }
-      } catch (e) {
-        albumHint.textContent = 'Failed to load albums.';
-      }
-    }
-
-    btnCreateAlbum.onclick = async () => {
-      const name = albumInput.value.trim();
-      if (!name) return;
-      try{
-        const r = await fetch('/api/albums', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ name }) });
-        const j = await r.json().catch(()=>({}));
-        if(!r.ok){ showResult('err', j.error || 'Album create failed'); return; }
-        showResult('ok', `Album created: ${j.albumName || j.id || name}`);
-        try { await loadAlbums(); } catch {}
-      }catch(err){ showResult('err', String(err)); }
-    };
-
-    btnCreate.onclick = async () => {
-      let albumId = null, albumName = null;
-      if (!albumSelectWrap.classList.contains('hidden') && albumSelect.value) {
-        albumId = albumSelect.value;
-      } else if (albumInput.value.trim()) {
-        albumName = albumInput.value.trim();
-      }
-      const payload = { maxUses: parseInt(usage.value, 10) };
-      const d = days.value.trim();
-      if (d) payload.expiresDays = parseInt(d, 10);
-      if (albumId) payload.albumId = albumId; else if (albumName) payload.albumName = albumName;
-      const pw = (passwordInput && passwordInput.value) ? passwordInput.value.trim() : '';
-      if (pw) payload.password = pw;
-      try{
-        const r = await fetch('/api/invites', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify(payload) });
-        const j = await r.json().catch(()=>({}));
-        if(!r.ok){ showResult('err', j.error || 'Failed to create link'); return; }
-        const link = j.absoluteUrl || (location.origin + j.url);
-        showResult('ok', '');
-        linkOut.value = link;
-        // Build QR via backend PNG generator (no external libs)
-        qrImg.src = `/api/qr?text=${encodeURIComponent(link)}`;
-        // Also refresh the managed links list and highlight the new entry
-        if (j && j.token) { try { LAST_CREATED_TOKEN = j.token; } catch {} }
-        try { await loadInvites(); } catch {}
-      }catch(err){ showResult('err', String(err)); }
-    };
-
-    // Logout handled via plain link to /logout (clears session + redirects)
-    btnCopy.onclick = ()=>{
-      const text = linkOut.value || '';
-      if (!text) return;
-      const flash = ()=>{ btnCopy.textContent='Copied'; setTimeout(()=>btnCopy.textContent='Copy', 1200); };
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        navigator.clipboard.writeText(text).then(flash).catch(()=>{
-          try{ const ta=document.createElement('textarea'); ta.value=text; ta.setAttribute('readonly',''); ta.style.position='absolute'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta); flash(); }catch{}
-        });
-      } else {
-        try{ const ta=document.createElement('textarea'); ta.value=text; ta.setAttribute('readonly',''); ta.style.position='absolute'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); document.execCommand('copy'); document.body.removeChild(ta); flash(); }catch{}
-      }
-    };
-    // header.js wires theme + ping and shows banner consistently
-    
-    loadAlbums();
-
-    // --- Manage UI logic ---
-    const searchQ = document.getElementById('searchQ');
-    const sortSel = document.getElementById('sortSel');
-    const btnRefresh = document.getElementById('btnRefresh');
-    const invitesTBody = document.getElementById('invitesTBody');
-    const chkAll = document.getElementById('chkAll');
-    const btnDisableSel = document.getElementById('btnDisableSel');
-    const btnEnableSel = document.getElementById('btnEnableSel');
-    const btnDeleteSel = document.getElementById('btnDeleteSel');
-    let INVITES = [];
-    let LAST_CREATED_TOKEN = null;
-
-    async function loadInvites(){
-      const params = new URLSearchParams();
-      const q = (searchQ.value||'').trim(); if (q) params.set('q', q);
-      const sort = (sortSel.value||'').trim(); if (sort) params.set('sort', sort);
-      try{
-        const r = await fetch('/api/invites?'+params.toString());
-        const j = await r.json();
-        INVITES = (j && j.items) ? j.items : [];
-      }catch{ INVITES = []; }
-      renderInvites();
-    }
-    function fmtDayMonth(iso){ try{ const d = new Date(iso); return d.toLocaleDateString(undefined,{ day:'2-digit', month:'short' }); }catch{return '—';} }
-    function statusBadge(row){
-      // Red reasons override disabled (yellow)
-      const inactive = String(row.inactiveReason||'');
-      if (/expired|claimed|exhausted/i.test(inactive)){
-        const label = inactive.charAt(0).toUpperCase()+inactive.slice(1);
-        return `<span class="inline-flex items-center rounded-full bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300 px-2 py-0.5">${label}</span>`;
-      }
-      if (row.active){
-        return `<span class="inline-flex items-center rounded-full bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300 px-2 py-0.5">Active</span>`;
-      }
-      if (/disabled/i.test(inactive)){
-        return `<span class="inline-flex items-center rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 px-2 py-0.5">Disabled</span>`;
-      }
-      return `<span>${row.active?'Active':'Inactive'}</span>`;
-    }
-    function renderInvites(){
-      invitesTBody.innerHTML = INVITES.map(row => {
-        const status = statusBadge(row);
-        const uses = (typeof row.remaining==='number') ? `${row.used||0}/${(row.maxUses<0)?'∞':row.maxUses}` : `${row.used||0}/${(row.maxUses<0)?'∞':row.maxUses??'?'}`;
-        const exp = row.expiresAt ? `<span title="${new Date(row.expiresAt).toLocaleString()}">${fmtDayMonth(row.expiresAt)}</span>` : '—';
-        const url = location.origin + '/invite/' + row.token;
-        return `
-          <tr class="border-b dark:border-gray-800" data-token="${row.token}">
-            <td class="py-2"><input class="chkRow" type="checkbox" data-token="${row.token}"/></td>
-            <td class="py-2" style="width:45%;">
-              <input class="inName w-full rounded border px-2 py-1 bg-white dark:bg-gray-900 dark:border-gray-700" data-token="${row.token}" value="${(row.name||'').replaceAll('"','&quot;')}" title="${(row.name||'').replaceAll('"','&quot;')}"/>
-            </td>
-            <td class="py-2">${status}</td>
-            <td class="py-2">${uses}</td>
-            <td class="py-2">
-              <input class="inExpires w-36 rounded border px-2 py-1 bg-white dark:bg-gray-900 dark:border-gray-700" type="date" data-token="${row.token}" value="${row.expiresAt? new Date(row.expiresAt).toISOString().slice(0,10):''}" title="${row.expiresAt? new Date(row.expiresAt).toLocaleString():''}"/>
-            </td>
-            <td class="py-2">${row.albumName || '—'}</td>
-            <td class="py-2">
-              <div class="flex items-center gap-1 whitespace-nowrap">
-                <button class="btnDetails group relative rounded-xl border px-2 py-1 text-xs dark:border-gray-600 inline-flex items-center" data-token="${row.token}" aria-label="Show details">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M12 3a9 9 0 1 1 0 18A9 9 0 0 1 12 3zm0 4a1.25 1.25 0 1 0 0 2.5A1.25 1.25 0 0 0 12 7zm-1.5 4.5h3v6h-3v-6z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Details</span>
-                </button>
-                <button class="btnQR group relative rounded-xl border px-2 py-1 text-xs dark:border-gray-600 inline-flex items-center" data-url="${url}" aria-label="Show QR code">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm12 0h-2v2h2v2h-4v2h6v-6h-2v0zm-4-2h2v2h-2v-2zm6-2h2v2h-2v-2z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Show QR</span>
-                </button>
-                <a class="group relative rounded-xl border px-2 py-1 text-xs dark:border-gray-600 inline-flex items-center" target="_blank" href="${url}" aria-label="Open link">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M14 3h7v7h-2V6.414l-9.293 9.293-1.414-1.414L17.586 5H14V3z"/><path d="M5 5h6v2H7v10h10v-4h2v6H5V5z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Open</span>
-                </a>
-                <button class="btnCopyLink group relative rounded-xl border px-2 py-1 text-xs dark:border-gray-600 inline-flex items-center" data-url="${url}" aria-label="Copy link">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14h13a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Copy</span>
-                </button>
-                <button class="btnSave group relative rounded-xl border px-2 py-1 text-xs dark:border-gray-600 inline-flex items-center opacity-50 cursor-not-allowed" data-token="${row.token}" aria-label="Save changes" disabled>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M17 3H7a2 2 0 0 0-2 2v14l7-3 7 3V5a2 2 0 0 0-2-2zM7 5h10v10l-5-2-5 2V5z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Save</span>
-                </button>
-              </div>
-            </td>
-          </tr>`;
-      }).join('');
-      // wire row actions
-      // helper to compute change state and toggle Save
-      function updateSaveState(token){
-        const inName = invitesTBody.querySelector(`.inName[data-token="${token}"]`);
-        const inExp = invitesTBody.querySelector(`.inExpires[data-token="${token}"]`);
-        const btn = invitesTBody.querySelector(`.btnSave[data-token="${token}"]`);
-        if (!inName || !inExp || !btn) return;
-        const origName = inName.getAttribute('data-original') || '';
-        const origExp = inExp.getAttribute('data-original') || '';
-        const curName = (inName.value||'').trim();
-        const curExp = inExp.value || '';
-        const changed = (curName !== origName) || (curExp !== origExp);
-        btn.disabled = !changed;
-        btn.classList.toggle('opacity-50', !changed);
-        btn.classList.toggle('cursor-not-allowed', !changed);
-      }
-      // set original values as data attributes and wire change listeners
-      INVITES.forEach(row => {
-        const token = row.token;
-        const inName = invitesTBody.querySelector(`.inName[data-token="${token}"]`);
-        const inExp = invitesTBody.querySelector(`.inExpires[data-token="${token}"]`);
-        if (inName) inName.setAttribute('data-original', (row.name||'').trim());
-        const dStr = row.expiresAt? new Date(row.expiresAt).toISOString().slice(0,10) : '';
-        if (inExp) inExp.setAttribute('data-original', dStr);
-        if (inName) inName.addEventListener('input', ()=>updateSaveState(token));
-        if (inExp) inExp.addEventListener('change', ()=>updateSaveState(token));
-        updateSaveState(token);
-      });
-
-      invitesTBody.querySelectorAll('.btnSave').forEach(btn => btn.onclick = async ()=>{
-        const token = btn.getAttribute('data-token');
-        if (btn.disabled) return;
-        const name = invitesTBody.querySelector(`.inName[data-token="${token}"]`).value.trim();
-        const expVal = invitesTBody.querySelector(`.inExpires[data-token="${token}"]`).value;
-        const payload = { name };
-        if (expVal) {
-          // Set to end-of-day local to avoid off-by-one day on save
-          const dt = new Date(expVal);
-          dt.setHours(23,59,59,999);
-          payload.expiresAt = dt.toISOString().slice(0,19);
-        } else { payload.expiresAt = null; }
-        try{
-          const r = await fetch(`/api/invite/${token}`, { method:'PATCH', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify(payload) });
-          if (!r.ok) throw new Error('Update failed');
-          await loadInvites();
-        }catch(e){ showResult('err', String(e.message||e)); }
-      });
-      invitesTBody.querySelectorAll('.btnDetails').forEach(btn => btn.onclick = async ()=>{
-        const token = btn.getAttribute('data-token');
-        try{
-          const r = await fetch(`/api/invite/${token}/uploads`);
-          const j = await r.json();
-          const items = (j && j.items) ? j.items : [];
-          const html = `
-            <div class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-              <div class="max-w-3xl w-full rounded-2xl bg-white dark:bg-gray-900 border dark:border-gray-700 p-4">
-                <div class="flex items-center justify-between mb-2">
-                  <div class="text-lg font-medium">Uploads</div>
-                  <button class="dlgClose rounded-lg border px-2 py-1 text-xs dark:border-gray-600">Close</button>
-                </div>
-                <div class="max-h-[60vh] overflow-auto">
-                  ${items.length? `<table class="w-full text-sm"><thead><tr class="text-left border-b dark:border-gray-700"><th class="py-1">When</th><th class="py-1">IP</th><th class="py-1">Filename</th><th class="py-1">Size</th><th class="py-1">Fingerprint</th></tr></thead><tbody>` + items.map(it=>`<tr class="border-b dark:border-gray-800"><td class="py-1">${new Date(it.uploadedAt).toLocaleString()}</td><td class="py-1">${it.ip||''}</td><td class="py-1">${it.filename||''}</td><td class="py-1">${(it.size||0).toLocaleString()}</td><td class="py-1">${(it.fingerprint||'').slice(0,16)}</td></tr>`).join('') + `</tbody></table>` : '<div class="text-sm text-gray-500">No uploads yet.</div>'}
-                </div>
-              </div>
-            </div>`;
-          const wrap = document.createElement('div');
-          wrap.innerHTML = html;
-          const dlg = wrap.firstElementChild;
-          document.body.appendChild(dlg);
-          dlg.querySelectorAll('.dlgClose').forEach(b=> b.onclick = ()=>{ try{ dlg.remove(); }catch{} });
-        }catch(e){ showResult('err', 'Failed to load uploads'); }
-      });
-      invitesTBody.querySelectorAll('.btnQR').forEach(btn => btn.onclick = ()=>{
-        const url = btn.getAttribute('data-url');
-        const html = `
-          <div class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-            <div class="max-w-md w-full rounded-2xl bg-white dark:bg-gray-900 border dark:border-gray-700 p-4">
-              <div class="flex items-center justify-between mb-2">
-                <div class="text-lg font-medium">QR Code</div>
-                <button class="dlgClose rounded-lg border px-2 py-1 text-xs dark:border-gray-600">Close</button>
-              </div>
-              <div class="flex items-center gap-4">
-                <img src="/api/qr?text=${encodeURIComponent(url)}" alt="QR" class="h-40 w-40"/>
-                <div class="text-sm break-all">${url}</div>
-              </div>
-            </div>
-          </div>`;
-        const wrap = document.createElement('div');
-        wrap.innerHTML = html;
-        const dlg = wrap.firstElementChild;
-        document.body.appendChild(dlg);
-        dlg.querySelectorAll('.dlgClose').forEach(b=> b.onclick = ()=>{ try{ dlg.remove(); }catch{} });
-      });
-      invitesTBody.querySelectorAll('.btnCopyLink').forEach(btn => btn.onclick = ()=>{
-        const url = btn.getAttribute('data-url');
-        const flash = ()=>{ btn.setAttribute('data-old', btn.innerHTML); btn.innerHTML='Copied'; setTimeout(()=>{ const old=btn.getAttribute('data-old'); if(old) btn.innerHTML=old; }, 1000); };
-        if (navigator.clipboard && navigator.clipboard.writeText) { navigator.clipboard.writeText(url).then(flash).catch(()=>{}); }
-      });
-      if (chkAll) chkAll.checked = false;
-      // Highlight and scroll to newly created invite if present
-      if (LAST_CREATED_TOKEN) {
-        const tr = invitesTBody.querySelector(`tr[data-token="${LAST_CREATED_TOKEN}"]`);
-        if (tr) {
-          tr.classList.add('bg-yellow-50','dark:bg-yellow-900/30');
-          try { tr.scrollIntoView({ behavior:'smooth', block:'center' }); } catch {}
-          setTimeout(()=>{ try{ tr.classList.remove('bg-yellow-50','dark:bg-yellow-900/30'); }catch{} }, 1600);
-        }
-        LAST_CREATED_TOKEN = null;
-      }
-    }
-    btnRefresh.onclick = loadInvites;
-    searchQ.oninput = ()=>{ clearTimeout(searchQ._t); searchQ._t = setTimeout(loadInvites, 300); };
-    sortSel.onchange = loadInvites;
-    chkAll.onchange = ()=>{ invitesTBody.querySelectorAll('.chkRow').forEach(c=>{ c.checked = chkAll.checked; }); };
-    btnDisableSel.onclick = async ()=>{
-      const toks = Array.from(invitesTBody.querySelectorAll('.chkRow:checked')).map(x=>x.getAttribute('data-token'));
-      if (!toks.length) return;
-      try{
-        const r = await fetch('/api/invites/bulk', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ tokens: toks, action:'disable' }) });
-        if (!r.ok) throw new Error('Bulk disable failed');
-        await loadInvites();
-      }catch(e){ showResult('err', String(e.message||e)); }
-    };
-    btnEnableSel.onclick = async ()=>{
-      const toks = Array.from(invitesTBody.querySelectorAll('.chkRow:checked')).map(x=>x.getAttribute('data-token'));
-      if (!toks.length) return;
-      try{
-        const r = await fetch('/api/invites/bulk', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ tokens: toks, action:'enable' }) });
-        if (!r.ok) throw new Error('Bulk enable failed');
-        await loadInvites();
-      }catch(e){ showResult('err', String(e.message||e)); }
-    };
-    btnDeleteSel.onclick = async ()=>{
-      const toks = Array.from(invitesTBody.querySelectorAll('.chkRow:checked')).map(x=>x.getAttribute('data-token'));
-      if (!toks.length) return;
-      if (!confirm('Are you sure? This cannot be undone.')) return;
-      try{
-        const r = await fetch('/api/invites/delete', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ tokens: toks }) });
-        if (!r.ok) throw new Error('Delete failed');
-        await loadInvites();
-      }catch(e){ showResult('err', String(e.message||e)); }
-    };
-
-    // Initial load
-    loadInvites();
-
-    // --- Platform Cookies UI logic ---
-    const cookiePlatform = document.getElementById('cookiePlatform');
-    const cookieString = document.getElementById('cookieString');
-    const btnSaveCookie = document.getElementById('btnSaveCookie');
-    const btnRefreshCookies = document.getElementById('btnRefreshCookies');
-    const cookiesTBody = document.getElementById('cookiesTBody');
-    const cookieResult = document.getElementById('cookieResult');
-    let COOKIES = [];
-    let PLATFORMS = [];
-
-    function showCookieResult(kind, text) {
-      cookieResult.className = 'rounded-xl border p-3 text-sm ' + (kind === 'ok'
-        ? 'border-green-200 bg-green-50 text-green-700 dark:bg-green-900 dark:border-green-700 dark:text-green-300'
-        : 'border-red-200 bg-red-50 text-red-700 dark:bg-red-900 dark:border-red-700 dark:text-red-300');
-      cookieResult.textContent = text;
-      cookieResult.classList.remove('hidden');
-      setTimeout(() => { cookieResult.classList.add('hidden'); }, 3000);
-    }
-
-    async function loadCookies() {
-      try {
-        const r = await fetch('/api/cookies');
-        const j = await r.json();
-        COOKIES = (j && j.items) ? j.items : [];
-        PLATFORMS = (j && j.platforms) ? j.platforms : [];
-        // Populate platform dropdown
-        cookiePlatform.innerHTML = '<option value="">Select platform...</option>' +
-          PLATFORMS.map(p => `<option value="${p}">${p.charAt(0).toUpperCase() + p.slice(1)}</option>`).join('');
-      } catch {
-        COOKIES = [];
-        PLATFORMS = [];
-      }
-      renderCookies();
-    }
-
-    function fmtDate(iso) {
-      try {
-        const d = new Date(iso);
-        return d.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: '2-digit' });
-      } catch {
-        return '-';
-      }
-    }
-
-    function renderCookies() {
-      if (COOKIES.length === 0) {
-        cookiesTBody.innerHTML = '<tr><td colspan="4" class="py-4 text-center text-gray-500">No cookies configured. Add one above to enable authenticated downloads.</td></tr>';
-        return;
-      }
-      cookiesTBody.innerHTML = COOKIES.map(c => {
-        const preview = c.cookie_preview || (c.cookie_string ? c.cookie_string.slice(0, 40) + '...' : '');
-        return `
-          <tr class="border-b dark:border-gray-800" data-platform="${c.platform}">
-            <td class="py-2 font-medium">${c.platform.charAt(0).toUpperCase() + c.platform.slice(1)}</td>
-            <td class="py-2 font-mono text-xs text-gray-600 dark:text-gray-400">${preview}</td>
-            <td class="py-2">${fmtDate(c.updated_at)}</td>
-            <td class="py-2">
-              <div class="flex items-center gap-1">
-                <button class="btnEditCookie group relative rounded-xl border px-2 py-1 text-xs dark:border-gray-600 inline-flex items-center" data-platform="${c.platform}" data-cookie="${(c.cookie_string || '').replaceAll('"', '&quot;')}" aria-label="Edit cookie">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Edit</span>
-                </button>
-                <button class="btnDeleteCookie group relative rounded-xl border px-2 py-1 text-xs border-red-400 text-red-600 dark:border-red-600 inline-flex items-center" data-platform="${c.platform}" aria-label="Delete cookie">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg>
-                  <span class="pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded bg-black text-white text-xs px-2 py-1 opacity-0 group-hover:opacity-100 dark:bg-gray-700">Delete</span>
-                </button>
-              </div>
-            </td>
-          </tr>`;
-      }).join('');
-
-      // Wire edit buttons
-      cookiesTBody.querySelectorAll('.btnEditCookie').forEach(btn => {
-        btn.onclick = () => {
-          const platform = btn.getAttribute('data-platform');
-          const cookie = btn.getAttribute('data-cookie');
-          cookiePlatform.value = platform;
-          cookieString.value = cookie;
-          cookieString.focus();
-        };
-      });
-
-      // Wire delete buttons
-      cookiesTBody.querySelectorAll('.btnDeleteCookie').forEach(btn => {
-        btn.onclick = async () => {
-          const platform = btn.getAttribute('data-platform');
-          if (!confirm(`Delete cookies for ${platform}?`)) return;
-          try {
-            const r = await fetch(`/api/cookies/${platform}`, { method: 'DELETE' });
-            if (!r.ok) throw new Error('Delete failed');
-            showCookieResult('ok', `Deleted cookies for ${platform}`);
-            await loadCookies();
-          } catch (e) {
-            showCookieResult('err', String(e.message || e));
-          }
-        };
-      });
-    }
-
-    btnSaveCookie.onclick = async () => {
-      const platform = cookiePlatform.value.trim();
-      const cookie = cookieString.value.trim();
-      if (!platform) {
-        showCookieResult('err', 'Please select a platform');
-        return;
-      }
-      if (!cookie) {
-        showCookieResult('err', 'Please enter a cookie string');
-        return;
-      }
-      try {
-        const r = await fetch('/api/cookies', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-          body: JSON.stringify({ platform, cookie_string: cookie })
-        });
-        const j = await r.json().catch(() => ({}));
-        if (!r.ok) {
-          showCookieResult('err', j.error || 'Save failed');
-          return;
-        }
-        showCookieResult('ok', `Saved cookies for ${platform}`);
-        cookiePlatform.value = '';
-        cookieString.value = '';
-        await loadCookies();
-      } catch (e) {
-        showCookieResult('err', String(e.message || e));
-      }
-    };
-
-    btnRefreshCookies.onclick = loadCookies;
-
-    // Load cookies on page load
-    loadCookies();
-
-    // Fetch version dynamically
-    fetch('/api/config')
-      .then(r => r.json())
-      .then(data => {
-        const versionEl = document.getElementById('version-link');
-        if (versionEl && data.version) {
-          versionEl.textContent = 'immich-drop v' + data.version;
-        }
-      })
-      .catch(() => {});
-  </script>
+  <script src="/static/menu.js"></script>
 </body>
 </html>

--- a/frontend/menu.js
+++ b/frontend/menu.js
@@ -1,0 +1,463 @@
+// menu.js -- Admin dashboard logic for immich-drop
+//
+// Security note: innerHTML is used below to render admin-only data
+// (invite tokens, album names, cookie previews) sourced from the
+// application's own API. All attribute values are escaped via escAttr().
+// This page is gated behind Immich authentication (session cookie check).
+// The escAttr helper sanitizes &, ", <, > to prevent injection.
+//
+// This is an intentional, reviewed use of innerHTML for a trusted
+// admin-only context. External/untrusted user input does not reach
+// these code paths.
+
+/* eslint-disable no-innerHTML */
+/* jshint -W060 */
+(function(){
+  var albumSelectWrap = document.getElementById('albumSelectWrap');
+  var albumSelect = document.getElementById('albumSelect');
+  var albumInputWrap = document.getElementById('albumInputWrap');
+  var albumInput = document.getElementById('albumInput');
+  var albumHint = document.getElementById('albumHint');
+  var btnCreateAlbum = document.getElementById('btnCreateAlbum');
+  var btnCreate = document.getElementById('btnCreate');
+  var usage = document.getElementById('usage');
+  var days = document.getElementById('days');
+  var result = document.getElementById('result');
+  var linkOut = document.getElementById('linkOut');
+  var btnCopy = document.getElementById('btnCopy');
+  var qrImg = document.getElementById('qrImg');
+  var passwordInput = document.getElementById('password');
+
+  function showResult(kind){
+    result.className = (kind==='ok' ? 'banner banner--ok mt-3' : 'banner banner--err mt-3');
+    result.classList.remove('hidden');
+  }
+
+  async function loadAlbums(){
+    try {
+      var r = await fetch('/api/albums');
+      if (r.status === 403) {
+        albumHint.textContent = 'Listing albums is forbidden with current credentials. You can still type a new album name or leave it blank.';
+        albumInputWrap.classList.remove('hidden');
+        return;
+      }
+      var list = await r.json();
+      if (Array.isArray(list)){
+        var opts = [{id:'', name:'-- No album --'}].concat(list.map(function(a){ return {id:a.id, name:(a.albumName || a.title || a.id)}; }));
+        albumSelect.innerHTML = opts.map(function(a){ return '<option value="'+escAttr(a.id)+'">'+escAttr(a.name)+'</option>'; }).join('');
+        albumSelectWrap.classList.remove('hidden');
+        albumInputWrap.classList.remove('hidden');
+        albumHint.textContent = 'Pick an existing album, or type a new name and click Create album.';
+      }
+    } catch (e) {
+      albumHint.textContent = 'Failed to load albums.';
+    }
+  }
+
+  btnCreateAlbum.onclick = async function(){
+    var name = albumInput.value.trim();
+    if (!name) return;
+    try{
+      var r = await fetch('/api/albums', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ name: name }) });
+      var j = await r.json().catch(function(){ return {}; });
+      if(!r.ok){ showResult('err'); return; }
+      showResult('ok');
+      try { await loadAlbums(); } catch(e2){}
+    }catch(err){ showResult('err'); }
+  };
+
+  btnCreate.onclick = async function(){
+    var albumId = null, albumName = null;
+    if (!albumSelectWrap.classList.contains('hidden') && albumSelect.value) {
+      albumId = albumSelect.value;
+    } else if (albumInput.value.trim()) {
+      albumName = albumInput.value.trim();
+    }
+    var payload = { maxUses: parseInt(usage.value, 10) };
+    var d = days.value.trim();
+    if (d) payload.expiresDays = parseInt(d, 10);
+    if (albumId) payload.albumId = albumId; else if (albumName) payload.albumName = albumName;
+    var pw = (passwordInput && passwordInput.value) ? passwordInput.value.trim() : '';
+    if (pw) payload.password = pw;
+    try{
+      var r = await fetch('/api/invites', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify(payload) });
+      var j = await r.json().catch(function(){ return {}; });
+      if(!r.ok){ showResult('err'); return; }
+      var link = j.absoluteUrl || (location.origin + j.url);
+      showResult('ok');
+      linkOut.value = link;
+      qrImg.src = '/api/qr?text='+encodeURIComponent(link);
+      if (j && j.token) { try { LAST_CREATED_TOKEN = j.token; } catch(e2){} }
+      try { await loadInvites(); } catch(e2){}
+    }catch(err){ showResult('err'); }
+  };
+
+  btnCopy.onclick = function(){
+    var text = linkOut.value || '';
+    if (!text) return;
+    var flash = function(){ btnCopy.textContent='Copied'; setTimeout(function(){ btnCopy.textContent='Copy'; }, 1200); };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(flash).catch(function(){});
+    }
+  };
+
+  loadAlbums();
+
+  // --- Manage Links ---
+  var searchQ = document.getElementById('searchQ');
+  var sortSel = document.getElementById('sortSel');
+  var btnRefresh = document.getElementById('btnRefresh');
+  var invitesTBody = document.getElementById('invitesTBody');
+  var chkAll = document.getElementById('chkAll');
+  var btnDisableSel = document.getElementById('btnDisableSel');
+  var btnEnableSel = document.getElementById('btnEnableSel');
+  var btnDeleteSel = document.getElementById('btnDeleteSel');
+  var INVITES = [];
+  var LAST_CREATED_TOKEN = null;
+
+  async function loadInvites(){
+    var params = new URLSearchParams();
+    var q = (searchQ.value||'').trim(); if (q) params.set('q', q);
+    var sort = (sortSel.value||'').trim(); if (sort) params.set('sort', sort);
+    try{
+      var r = await fetch('/api/invites?'+params.toString());
+      var j = await r.json();
+      INVITES = (j && j.items) ? j.items : [];
+    }catch(e){ INVITES = []; }
+    renderInvites();
+  }
+
+  // HTML attribute escaper for server-sourced admin data
+  function escAttr(s){ return String(s||'').replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+  function statusBadge(row){
+    var inactive = String(row.inactiveReason||'');
+    if (/expired|claimed|exhausted/i.test(inactive)){
+      var label = inactive.charAt(0).toUpperCase()+inactive.slice(1);
+      return '<span class="badge badge--red">'+escAttr(label)+'</span>';
+    }
+    if (row.active) return '<span class="badge badge--green">Active</span>';
+    if (/disabled/i.test(inactive)) return '<span class="badge badge--amber">Disabled</span>';
+    return '<span class="badge">'+(row.active?'Active':'Inactive')+'</span>';
+  }
+
+  function renderInvites(){
+    var rows = '';
+    for (var i=0; i<INVITES.length; i++){
+      var row = INVITES[i];
+      var status = statusBadge(row);
+      var uses = (row.used||0)+'/'+(row.maxUses<0?'Inf':row.maxUses);
+      var url = location.origin + '/invite/' + row.token;
+      var nameEsc = escAttr(row.name);
+      var expVal = row.expiresAt ? new Date(row.expiresAt).toISOString().slice(0,10) : '';
+      var expTitle = row.expiresAt ? new Date(row.expiresAt).toLocaleString() : 'No expiry';
+      rows += '<tr data-token="'+escAttr(row.token)+'">'
+        + '<td class="td-checkbox"><input class="chkRow" type="checkbox" data-token="'+escAttr(row.token)+'"/></td>'
+        + '<td class="td-name" data-label="Name"><input class="inName input" data-token="'+escAttr(row.token)+'" value="'+nameEsc+'" title="'+nameEsc+'"/></td>'
+        + '<td data-label="Status">'+status+'</td>'
+        + '<td data-label="Uses">'+escAttr(uses)+'</td>'
+        + '<td data-label="Expires"><input class="inExpires input" type="date" data-token="'+escAttr(row.token)+'" value="'+escAttr(expVal)+'" title="'+escAttr(expTitle)+'" style="width:140px;"/></td>'
+        + '<td data-label="Album">'+escAttr(row.albumName||'--')+'</td>'
+        + '<td class="td-actions" data-label="">'
+        + '<div class="flex items-center gap-2">'
+        + '<button class="btnDetails btn btn--sm btn--icon has-tooltip" data-token="'+escAttr(row.token)+'" aria-label="Details"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M12 3a9 9 0 1 1 0 18A9 9 0 0 1 12 3zm0 4a1.25 1.25 0 1 0 0 2.5A1.25 1.25 0 0 0 12 7zm-1.5 4.5h3v6h-3v-6z"/></svg><span class="tooltip">Details</span></button>'
+        + '<button class="btnQR btn btn--sm btn--icon has-tooltip" data-url="'+escAttr(url)+'" aria-label="QR"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm12 0h-2v2h2v2h-4v2h6v-6h-2v0zm-4-2h2v2h-2v-2zm6-2h2v2h-2v-2z"/></svg><span class="tooltip">QR</span></button>'
+        + '<a class="btn btn--sm btn--icon has-tooltip" target="_blank" href="'+escAttr(url)+'" aria-label="Open"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M14 3h7v7h-2V6.414l-9.293 9.293-1.414-1.414L17.586 5H14V3z"/><path d="M5 5h6v2H7v10h10v-4h2v6H5V5z"/></svg><span class="tooltip">Open</span></a>'
+        + '<button class="btnCopyLink btn btn--sm btn--icon has-tooltip" data-url="'+escAttr(url)+'" aria-label="Copy"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M16 1H4a2 2 0 0 0-2 2v12h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14h13a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg><span class="tooltip">Copy</span></button>'
+        + '<button class="btnSave btn btn--sm btn--icon has-tooltip" data-token="'+escAttr(row.token)+'" aria-label="Save" disabled style="opacity:0.4;"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M17 3H7a2 2 0 0 0-2 2v14l7-3 7 3V5a2 2 0 0 0-2-2zM7 5h10v10l-5-2-5 2V5z"/></svg><span class="tooltip">Save</span></button>'
+        + '</div></td></tr>';
+    }
+    invitesTBody.innerHTML = rows;
+
+    function updateSaveState(token){
+      var inName = invitesTBody.querySelector('.inName[data-token="'+token+'"]');
+      var inExp = invitesTBody.querySelector('.inExpires[data-token="'+token+'"]');
+      var btn = invitesTBody.querySelector('.btnSave[data-token="'+token+'"]');
+      if (!inName || !inExp || !btn) return;
+      var changed = ((inName.value||'').trim() !== (inName.getAttribute('data-original')||'')) || ((inExp.value||'') !== (inExp.getAttribute('data-original')||''));
+      btn.disabled = !changed;
+      btn.style.opacity = changed ? '1' : '0.4';
+    }
+
+    INVITES.forEach(function(row){
+      var token = row.token;
+      var inName = invitesTBody.querySelector('.inName[data-token="'+token+'"]');
+      var inExp = invitesTBody.querySelector('.inExpires[data-token="'+token+'"]');
+      if (inName) inName.setAttribute('data-original', (row.name||'').trim());
+      var dStr = row.expiresAt ? new Date(row.expiresAt).toISOString().slice(0,10) : '';
+      if (inExp) inExp.setAttribute('data-original', dStr);
+      if (inName) inName.addEventListener('input', function(){ updateSaveState(token); });
+      if (inExp) inExp.addEventListener('change', function(){ updateSaveState(token); });
+      updateSaveState(token);
+    });
+
+    invitesTBody.querySelectorAll('.btnSave').forEach(function(btn){
+      btn.onclick = async function(){
+        var token = btn.getAttribute('data-token');
+        if (btn.disabled) return;
+        var name = invitesTBody.querySelector('.inName[data-token="'+token+'"]').value.trim();
+        var expVal = invitesTBody.querySelector('.inExpires[data-token="'+token+'"]').value;
+        var payload = { name: name };
+        if (expVal) { var dt = new Date(expVal); dt.setHours(23,59,59,999); payload.expiresAt = dt.toISOString().slice(0,19); } else { payload.expiresAt = null; }
+        try{
+          var r = await fetch('/api/invite/'+token, { method:'PATCH', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify(payload) });
+          if (!r.ok) throw new Error('Update failed');
+          await loadInvites();
+        }catch(e){ showResult('err'); }
+      };
+    });
+
+    invitesTBody.querySelectorAll('.btnDetails').forEach(function(btn){
+      btn.onclick = async function(){
+        var token = btn.getAttribute('data-token');
+        try{
+          var r = await fetch('/api/invite/'+token+'/uploads');
+          var j = await r.json();
+          var items = (j && j.items) ? j.items : [];
+          var dlg = document.createElement('div');
+          dlg.className = 'modal-overlay';
+          var panel = document.createElement('div');
+          panel.className = 'modal-panel';
+          var hdr = document.createElement('div');
+          hdr.className = 'modal-header';
+          var h3 = document.createElement('h3');
+          h3.textContent = 'Uploads';
+          var closeBtn = document.createElement('button');
+          closeBtn.className = 'btn btn--sm';
+          closeBtn.textContent = 'Close';
+          closeBtn.onclick = function(){ dlg.remove(); };
+          hdr.appendChild(h3);
+          hdr.appendChild(closeBtn);
+          panel.appendChild(hdr);
+          var body = document.createElement('div');
+          body.style.maxHeight = '60vh';
+          body.style.overflow = 'auto';
+          if (items.length){
+            var tbl = '<table class="data-table"><thead><tr><th>When</th><th>IP</th><th>Filename</th><th>Size</th></tr></thead><tbody>';
+            items.forEach(function(it){
+              tbl += '<tr><td>'+escAttr(new Date(it.uploadedAt).toLocaleString())+'</td><td>'+escAttr(it.ip)+'</td><td>'+escAttr(it.filename)+'</td><td>'+escAttr((it.size||0).toLocaleString())+'</td></tr>';
+            });
+            tbl += '</tbody></table>';
+            body.innerHTML = tbl;
+          } else {
+            body.textContent = 'No uploads yet.';
+            body.className = 'text-sm text-secondary';
+          }
+          panel.appendChild(body);
+          dlg.appendChild(panel);
+          document.body.appendChild(dlg);
+          dlg.onclick = function(e){ if(e.target===dlg) dlg.remove(); };
+        }catch(e){ showResult('err'); }
+      };
+    });
+
+    invitesTBody.querySelectorAll('.btnQR').forEach(function(btn){
+      btn.onclick = function(){
+        var url = btn.getAttribute('data-url');
+        var dlg = document.createElement('div');
+        dlg.className = 'modal-overlay';
+        var panel = document.createElement('div');
+        panel.className = 'modal-panel';
+        panel.style.maxWidth = '400px';
+        var hdr = document.createElement('div');
+        hdr.className = 'modal-header';
+        var h3 = document.createElement('h3');
+        h3.textContent = 'QR Code';
+        var closeBtn = document.createElement('button');
+        closeBtn.className = 'btn btn--sm';
+        closeBtn.textContent = 'Close';
+        closeBtn.onclick = function(){ dlg.remove(); };
+        hdr.appendChild(h3);
+        hdr.appendChild(closeBtn);
+        panel.appendChild(hdr);
+        var body = document.createElement('div');
+        body.className = 'flex items-center';
+        body.style.gap = '16px';
+        var img = document.createElement('img');
+        img.src = '/api/qr?text='+encodeURIComponent(url);
+        img.alt = 'QR';
+        img.style.width = '140px';
+        img.style.height = '140px';
+        var linkEl = document.createElement('div');
+        linkEl.className = 'text-sm';
+        linkEl.style.wordBreak = 'break-all';
+        linkEl.textContent = url;
+        body.appendChild(img);
+        body.appendChild(linkEl);
+        panel.appendChild(body);
+        dlg.appendChild(panel);
+        document.body.appendChild(dlg);
+        dlg.onclick = function(e){ if(e.target===dlg) dlg.remove(); };
+      };
+    });
+
+    invitesTBody.querySelectorAll('.btnCopyLink').forEach(function(btn){
+      btn.onclick = function(){
+        var url = btn.getAttribute('data-url');
+        var origHTML = btn.innerHTML;
+        var flash = function(){
+          btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/></svg>';
+          setTimeout(function(){ btn.innerHTML = origHTML; }, 1000);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) { navigator.clipboard.writeText(url).then(flash).catch(function(){}); }
+      };
+    });
+
+    if (chkAll) chkAll.checked = false;
+    if (LAST_CREATED_TOKEN) {
+      var tr = invitesTBody.querySelector('tr[data-token="'+LAST_CREATED_TOKEN+'"]');
+      if (tr) {
+        tr.style.background = 'var(--green-bg)';
+        try { tr.scrollIntoView({ behavior:'smooth', block:'center' }); } catch(e2){}
+        setTimeout(function(){ try{ tr.style.background = ''; }catch(e2){} }, 1600);
+      }
+      LAST_CREATED_TOKEN = null;
+    }
+  }
+
+  btnRefresh.onclick = loadInvites;
+  searchQ.oninput = function(){ clearTimeout(searchQ._t); searchQ._t = setTimeout(loadInvites, 300); };
+  sortSel.onchange = loadInvites;
+  chkAll.onchange = function(){ invitesTBody.querySelectorAll('.chkRow').forEach(function(c){ c.checked = chkAll.checked; }); };
+
+  btnDisableSel.onclick = async function(){
+    var toks = Array.from(invitesTBody.querySelectorAll('.chkRow:checked')).map(function(x){ return x.getAttribute('data-token'); });
+    if (!toks.length) return;
+    try{
+      var r = await fetch('/api/invites/bulk', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ tokens: toks, action:'disable' }) });
+      if (!r.ok) throw new Error('Bulk disable failed');
+      await loadInvites();
+    }catch(e){ showResult('err'); }
+  };
+  btnEnableSel.onclick = async function(){
+    var toks = Array.from(invitesTBody.querySelectorAll('.chkRow:checked')).map(function(x){ return x.getAttribute('data-token'); });
+    if (!toks.length) return;
+    try{
+      var r = await fetch('/api/invites/bulk', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ tokens: toks, action:'enable' }) });
+      if (!r.ok) throw new Error('Bulk enable failed');
+      await loadInvites();
+    }catch(e){ showResult('err'); }
+  };
+  btnDeleteSel.onclick = async function(){
+    var toks = Array.from(invitesTBody.querySelectorAll('.chkRow:checked')).map(function(x){ return x.getAttribute('data-token'); });
+    if (!toks.length) return;
+    if (!confirm('Are you sure? This cannot be undone.')) return;
+    try{
+      var r = await fetch('/api/invites/delete', { method:'POST', headers:{'Content-Type':'application/json','Accept':'application/json'}, body: JSON.stringify({ tokens: toks }) });
+      if (!r.ok) throw new Error('Delete failed');
+      await loadInvites();
+    }catch(e){ showResult('err'); }
+  };
+
+  loadInvites();
+
+  // --- Platform Cookies ---
+  var cookiePlatform = document.getElementById('cookiePlatform');
+  var cookieString = document.getElementById('cookieString');
+  var btnSaveCookie = document.getElementById('btnSaveCookie');
+  var btnRefreshCookies = document.getElementById('btnRefreshCookies');
+  var cookiesTBody = document.getElementById('cookiesTBody');
+  var cookieResult = document.getElementById('cookieResult');
+  var COOKIES = [];
+  var PLATFORMS = [];
+
+  function showCookieResult(kind, text) {
+    cookieResult.className = 'banner mt-3 ' + (kind === 'ok' ? 'banner--ok' : 'banner--err');
+    cookieResult.textContent = text;
+    cookieResult.classList.remove('hidden');
+    setTimeout(function(){ cookieResult.classList.add('hidden'); }, 3000);
+  }
+
+  async function loadCookies() {
+    try {
+      var r = await fetch('/api/cookies');
+      var j = await r.json();
+      COOKIES = (j && j.items) ? j.items : [];
+      PLATFORMS = (j && j.platforms) ? j.platforms : [];
+      cookiePlatform.innerHTML = '<option value="">Select...</option>' +
+        PLATFORMS.map(function(p){ return '<option value="'+escAttr(p)+'">'+escAttr(p.charAt(0).toUpperCase()+p.slice(1))+'</option>'; }).join('');
+    } catch(e) {
+      COOKIES = [];
+      PLATFORMS = [];
+    }
+    renderCookies();
+  }
+
+  function fmtDate(iso) {
+    try { var d = new Date(iso); return d.toLocaleDateString(undefined, { day: '2-digit', month: 'short', year: '2-digit' }); }
+    catch(e) { return '-'; }
+  }
+
+  function renderCookies() {
+    if (COOKIES.length === 0) {
+      cookiesTBody.innerHTML = '<tr><td colspan="4" class="text-sm text-secondary" style="padding:16px;text-align:center;">No cookies configured.</td></tr>';
+      return;
+    }
+    var rows = '';
+    for (var i=0; i<COOKIES.length; i++){
+      var c = COOKIES[i];
+      var preview = c.cookie_preview || (c.cookie_string ? c.cookie_string.slice(0, 40) + '...' : '');
+      rows += '<tr data-platform="'+escAttr(c.platform)+'">'
+        + '<td data-label="Platform" style="font-weight:500;">'+escAttr(c.platform.charAt(0).toUpperCase()+c.platform.slice(1))+'</td>'
+        + '<td data-label="Preview" class="text-mono text-xs text-secondary">'+escAttr(preview)+'</td>'
+        + '<td data-label="Updated">'+escAttr(fmtDate(c.updated_at))+'</td>'
+        + '<td class="td-actions" data-label="">'
+        + '<div class="flex items-center gap-2">'
+        + '<button class="btnEditCookie btn btn--sm btn--icon has-tooltip" data-platform="'+escAttr(c.platform)+'" data-cookie="'+escAttr(c.cookie_string)+'" aria-label="Edit"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg><span class="tooltip">Edit</span></button>'
+        + '<button class="btnDeleteCookie btn btn--sm btn--icon btn--danger has-tooltip" data-platform="'+escAttr(c.platform)+'" aria-label="Delete"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"/></svg><span class="tooltip">Delete</span></button>'
+        + '</div></td></tr>';
+    }
+    cookiesTBody.innerHTML = rows;
+
+    cookiesTBody.querySelectorAll('.btnEditCookie').forEach(function(btn){
+      btn.onclick = function(){
+        cookiePlatform.value = btn.getAttribute('data-platform');
+        cookieString.value = btn.getAttribute('data-cookie');
+        cookieString.focus();
+      };
+    });
+    cookiesTBody.querySelectorAll('.btnDeleteCookie').forEach(function(btn){
+      btn.onclick = async function(){
+        var platform = btn.getAttribute('data-platform');
+        if (!confirm('Delete cookies for '+platform+'?')) return;
+        try {
+          var r = await fetch('/api/cookies/'+platform, { method: 'DELETE' });
+          if (!r.ok) throw new Error('Delete failed');
+          showCookieResult('ok', 'Deleted cookies for '+platform);
+          await loadCookies();
+        } catch (e) { showCookieResult('err', String(e.message || e)); }
+      };
+    });
+  }
+
+  btnSaveCookie.onclick = async function(){
+    var platform = cookiePlatform.value.trim();
+    var cookie = cookieString.value.trim();
+    if (!platform) { showCookieResult('err', 'Please select a platform'); return; }
+    if (!cookie) { showCookieResult('err', 'Please enter a cookie string'); return; }
+    try {
+      var r = await fetch('/api/cookies', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify({ platform: platform, cookie_string: cookie })
+      });
+      var j = await r.json().catch(function(){ return {}; });
+      if (!r.ok) { showCookieResult('err', j.error || 'Save failed'); return; }
+      showCookieResult('ok', 'Saved cookies for '+platform);
+      cookiePlatform.value = '';
+      cookieString.value = '';
+      await loadCookies();
+    } catch (e) { showCookieResult('err', String(e.message || e)); }
+  };
+
+  btnRefreshCookies.onclick = loadCookies;
+  loadCookies();
+
+  fetch('/api/config')
+    .then(function(r){ return r.json(); })
+    .then(function(data){
+      var versionEl = document.getElementById('version-link');
+      if (versionEl && data.version) versionEl.textContent = 'immich-drop v' + data.version;
+    })
+    .catch(function(){});
+})();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,554 @@
+/* ============================================================
+   immich-drop -- shared stylesheet
+   Replaces Tailwind CDN with purpose-built CSS.
+   ============================================================ */
+
+/* --- Google Font --- */
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+/* --- Design tokens --- */
+:root {
+  --font-body: 'DM Sans', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  --bg: #f8f8f8;
+  --bg-card: #ffffff;
+  --bg-input: #ffffff;
+  --bg-hover: #f0f0f0;
+  --border: #e0e0e0;
+  --border-focus: #888;
+  --text: #1a1a1a;
+  --text-secondary: #6b6b6b;
+  --text-tertiary: #999;
+  --accent: #1a1a1a;
+  --accent-text: #ffffff;
+  --radius: 10px;
+  --radius-lg: 14px;
+  --shadow-card: 0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06);
+
+  /* Status colors */
+  --green-bg: #ecfdf5;
+  --green-border: #a7f3d0;
+  --green-text: #065f46;
+  --red-bg: #fef2f2;
+  --red-border: #fecaca;
+  --red-text: #991b1b;
+  --amber-bg: #fffbeb;
+  --amber-border: #fde68a;
+  --amber-text: #92400e;
+  --blue-bg: #eff6ff;
+  --blue-border: #bfdbfe;
+  --blue-text: #1e40af;
+}
+
+html.dark {
+  --bg: #111111;
+  --bg-card: #1a1a1a;
+  --bg-input: #222222;
+  --bg-hover: #2a2a2a;
+  --border: #333333;
+  --border-focus: #666;
+  --text: #e8e8e8;
+  --text-secondary: #999;
+  --text-tertiary: #666;
+  --accent: #e8e8e8;
+  --accent-text: #111111;
+  --shadow-card: 0 1px 3px rgba(0,0,0,0.3);
+
+  --green-bg: #052e16;
+  --green-border: #166534;
+  --green-text: #86efac;
+  --red-bg: #450a0a;
+  --red-border: #7f1d1d;
+  --red-text: #fca5a5;
+  --amber-bg: #451a03;
+  --amber-border: #78350f;
+  --amber-text: #fcd34d;
+  --blue-bg: #1e3a5f;
+  --blue-border: #1e40af;
+  --blue-text: #93c5fd;
+}
+
+/* --- Reset & base --- */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  min-height: 100svh;
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  transition: background-color 0.2s, color 0.2s;
+}
+
+a { color: inherit; }
+
+/* --- Layout --- */
+.page-wrap {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px 20px 48px;
+}
+.page-wrap--wide { max-width: 860px; }
+
+/* --- Header / Nav --- */
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+.site-header h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+}
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+  text-decoration: none;
+}
+.btn:hover { background: var(--bg-hover); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.btn--primary {
+  background: var(--accent);
+  color: var(--accent-text);
+  border-color: var(--accent);
+}
+.btn--primary:hover { opacity: 0.85; background: var(--accent); }
+
+.btn--danger {
+  border-color: var(--red-border);
+  color: var(--red-text);
+}
+.btn--danger:hover { background: var(--red-bg); }
+
+.btn--sm {
+  font-size: 0.75rem;
+  padding: 5px 10px;
+}
+
+.btn--icon {
+  padding: 6px 8px;
+}
+.btn--icon svg { width: 16px; height: 16px; }
+
+.btn--full { width: 100%; }
+
+/* --- Cards / Sections --- */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  box-shadow: var(--shadow-card);
+  margin-bottom: 16px;
+}
+.card--flush { padding: 0; }
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+.card-header h2, .card-header h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* --- Form elements --- */
+.form-label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+.form-hint {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  margin-top: 4px;
+}
+
+.input, select.input, textarea.input {
+  display: block;
+  width: 100%;
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text);
+  transition: border-color 0.15s;
+  -webkit-appearance: none;
+  appearance: none;
+}
+select.input {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+}
+textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8125rem; }
+.input:focus, select.input:focus, textarea.input:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+.input::placeholder { color: var(--text-tertiary); }
+.input[readonly] { background: var(--bg); }
+
+.form-group { margin-bottom: 14px; }
+.form-row {
+  display: grid;
+  gap: 14px;
+}
+.form-row--2 { grid-template-columns: 1fr 1fr; }
+.form-row--3 { grid-template-columns: 1fr 1fr 1fr; }
+@media (max-width: 600px) {
+  .form-row--2, .form-row--3 { grid-template-columns: 1fr; }
+}
+
+/* --- Dropzone --- */
+.dropzone {
+  border: 2px dashed var(--border);
+  border-radius: var(--radius-lg);
+  padding: 40px 20px;
+  text-align: center;
+  background: var(--bg-card);
+  transition: border-color 0.15s, background 0.15s;
+  margin-bottom: 16px;
+}
+.dropzone.drag-over {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+.dropzone-icon {
+  width: 36px;
+  height: 36px;
+  margin: 0 auto 8px;
+  opacity: 0.5;
+  color: var(--text-secondary);
+}
+.dropzone-text { font-weight: 500; font-size: 0.9375rem; color: var(--text); }
+.dropzone-sub { font-size: 0.8125rem; color: var(--text-secondary); margin-top: 2px; }
+.dropzone-privacy { font-size: 0.8125rem; color: var(--text-tertiary); margin-top: 12px; }
+.dropzone .btn { margin-top: 12px; }
+
+@media (max-width: 600px) {
+  .dropzone { padding: 28px 16px; }
+  .dropzone-desktop { display: none; }
+}
+
+/* --- Tables --- */
+.data-table {
+  width: 100%;
+  font-size: 0.8125rem;
+  border-collapse: collapse;
+}
+.data-table th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--text-secondary);
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.data-table td {
+  padding: 10px 10px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.data-table tbody tr:last-child td { border-bottom: none; }
+.data-table input[type="checkbox"] { margin: 0; }
+
+/* Mobile: convert table to stacked cards */
+@media (max-width: 700px) {
+  .data-table--responsive thead { display: none; }
+  .data-table--responsive,
+  .data-table--responsive tbody,
+  .data-table--responsive tr,
+  .data-table--responsive td {
+    display: block;
+    width: 100%;
+  }
+  .data-table--responsive tr {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .data-table--responsive tr:last-child { border-bottom: none; }
+  .data-table--responsive td {
+    padding: 3px 0;
+    border: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .data-table--responsive td::before {
+    content: attr(data-label);
+    font-weight: 500;
+    color: var(--text-secondary);
+    min-width: 80px;
+    flex-shrink: 0;
+    font-size: 0.75rem;
+  }
+  .data-table--responsive td.td-actions {
+    margin-top: 6px;
+  }
+  .data-table--responsive td.td-actions::before { content: ''; min-width: 0; }
+  .data-table--responsive td.td-checkbox { display: none; }
+  .data-table--responsive td.td-name .input { font-size: 0.875rem; font-weight: 500; }
+}
+
+/* --- Status badges --- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 6px;
+}
+.badge--green { background: var(--green-bg); color: var(--green-text); }
+.badge--red { background: var(--red-bg); color: var(--red-text); }
+.badge--amber { background: var(--amber-bg); color: var(--amber-text); }
+
+/* --- Banner / alerts --- */
+.banner {
+  padding: 10px 16px;
+  border-radius: var(--radius);
+  font-size: 0.8125rem;
+  text-align: center;
+  margin-bottom: 16px;
+}
+.banner--ok { background: var(--green-bg); border: 1px solid var(--green-border); color: var(--green-text); }
+.banner--warn { background: var(--amber-bg); border: 1px solid var(--amber-border); color: var(--amber-text); }
+.banner--err { background: var(--red-bg); border: 1px solid var(--red-border); color: var(--red-text); }
+
+/* --- Upload progress items --- */
+.upload-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  box-shadow: var(--shadow-card);
+  margin-bottom: 8px;
+}
+.upload-item__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.upload-item__name {
+  font-weight: 500;
+  font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.upload-item__size {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+.upload-item__status {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  flex-shrink: 0;
+}
+.upload-item__bar {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: var(--bg);
+  margin-top: 10px;
+  overflow: hidden;
+}
+.upload-item__fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+  background: var(--accent);
+}
+.upload-item__fill--done { background: var(--green-text); }
+.upload-item__fill--dup { background: var(--amber-text); }
+.upload-item__fill--err { background: var(--red-text); }
+.upload-item__msg {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-top: 6px;
+}
+
+/* --- Stats bar --- */
+.stats-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+.stats-bar__counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+}
+.stats-bar__actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* --- URL uploader --- */
+.url-section .platform-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 10px;
+}
+.platform-tag {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+/* --- QR / Modal overlays --- */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 50;
+}
+.modal-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 20px;
+  max-width: 600px;
+  width: 100%;
+  max-height: 80vh;
+  overflow: auto;
+}
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.modal-header h3 { font-size: 1rem; font-weight: 600; }
+
+/* --- Tooltip (hover) --- */
+.has-tooltip { position: relative; }
+.has-tooltip .tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent);
+  color: var(--accent-text);
+  font-size: 0.6875rem;
+  padding: 3px 8px;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.has-tooltip:hover .tooltip { opacity: 1; }
+
+/* --- Footer --- */
+.site-footer {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  padding: 24px 0 0;
+}
+.site-footer a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.site-footer a:hover { color: var(--text-secondary); }
+
+/* --- Utility --- */
+.hidden { display: none !important; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+.text-mono { font-family: var(--font-mono); }
+.text-sm { font-size: 0.8125rem; }
+.text-xs { font-size: 0.75rem; }
+.text-secondary { color: var(--text-secondary); }
+.text-tertiary { color: var(--text-tertiary); }
+.mt-2 { margin-top: 8px; }
+.mt-3 { margin-top: 12px; }
+.mt-4 { margin-top: 16px; }
+.mb-2 { margin-bottom: 8px; }
+.mb-3 { margin-bottom: 12px; }
+.gap-2 { gap: 8px; }
+.flex { display: flex; }
+.flex-wrap { flex-wrap: wrap; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.justify-end { justify-content: flex-end; }
+.w-full { width: 100%; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.min-w-0 { min-width: 0; }
+.flex-1 { flex: 1 1 0%; min-width: 0; }
+.space-y > * + * { margin-top: 12px; }
+.space-y-sm > * + * { margin-top: 8px; }
+
+/* --- Spinner animation --- */
+@keyframes spin { to { transform: rotate(360deg); } }
+.animate-spin { animation: spin 0.8s linear infinite; }
+
+/* --- Scrollbar (subtle) --- */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -16,15 +16,18 @@
   --bg-input: #ffffff;
   --bg-hover: #f0f0f0;
   --border: #e0e0e0;
-  --border-focus: #888;
+  --border-focus: #4250af;
   --text: #1a1a1a;
   --text-secondary: #6b6b6b;
   --text-tertiary: #999;
-  --accent: #1a1a1a;
+  --accent: #4250af;
+  --accent-hover: #3644a0;
+  --accent-subtle: #eef1fb;
   --accent-text: #ffffff;
   --radius: 10px;
   --radius-lg: 14px;
   --shadow-card: 0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06);
+  --shadow-focus: 0 0 0 3px rgba(66, 80, 175, 0.15);
 
   /* Status colors */
   --green-bg: #ecfdf5;
@@ -47,13 +50,16 @@ html.dark {
   --bg-input: #222222;
   --bg-hover: #2a2a2a;
   --border: #333333;
-  --border-focus: #666;
+  --border-focus: #accbfa;
   --text: #e8e8e8;
   --text-secondary: #999;
   --text-tertiary: #666;
-  --accent: #e8e8e8;
-  --accent-text: #111111;
+  --accent: #accbfa;
+  --accent-hover: #8db8f8;
+  --accent-subtle: #1a2040;
+  --accent-text: #0a0a0a;
   --shadow-card: 0 1px 3px rgba(0,0,0,0.3);
+  --shadow-focus: 0 0 0 3px rgba(172, 203, 250, 0.2);
 
   --green-bg: #052e16;
   --green-border: #166534;
@@ -148,7 +154,7 @@ a { color: inherit; }
   color: var(--accent-text);
   border-color: var(--accent);
 }
-.btn--primary:hover { opacity: 0.85; background: var(--accent); }
+.btn--primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
 
 .btn--danger {
   border-color: var(--red-border);
@@ -232,6 +238,7 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
 .input:focus, select.input:focus, textarea.input:focus {
   outline: none;
   border-color: var(--border-focus);
+  box-shadow: var(--shadow-focus);
 }
 .input::placeholder { color: var(--text-tertiary); }
 .input[readonly] { background: var(--bg); }
@@ -259,7 +266,7 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
 }
 .dropzone.drag-over {
   border-color: var(--accent);
-  background: var(--bg-hover);
+  background: var(--accent-subtle);
 }
 .dropzone-icon {
   width: 36px;
@@ -441,10 +448,11 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
 }
 
 /* --- URL uploader --- */
-.url-section .platform-tags {
+.platform-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  align-items: center;
+  gap: 6px;
   margin-top: 10px;
 }
 .platform-tag {
@@ -452,9 +460,9 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
   font-weight: 500;
   padding: 3px 8px;
   border-radius: 6px;
-  background: var(--bg);
-  color: var(--text-secondary);
-  border: 1px solid var(--border);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  border: 1px solid transparent;
 }
 
 /* --- QR / Modal overlays --- */
@@ -515,8 +523,9 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
 .site-footer a {
   text-decoration: underline;
   text-underline-offset: 2px;
+  color: var(--accent);
 }
-.site-footer a:hover { color: var(--text-secondary); }
+.site-footer a:hover { opacity: 0.8; }
 
 /* --- Utility --- */
 .hidden { display: none !important; }

--- a/frontend/url-uploader.js
+++ b/frontend/url-uploader.js
@@ -25,7 +25,7 @@ class UrlUploader {
                 <div class="url-input-section">
                     <h3 class="text-lg font-semibold mb-2 dark:text-white">Upload from URL</h3>
                     <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-                        Paste a link from TikTok, Instagram, Facebook, Reddit, YouTube, or Twitter
+                        Paste a link from TikTok, Instagram, Facebook, Reddit, YouTube, Twitter, or any direct image URL
                     </p>
 
                     <div style="display: flex; flex-direction: column; gap: 0.5rem;">

--- a/frontend/url-uploader.js
+++ b/frontend/url-uploader.js
@@ -164,13 +164,22 @@ class UrlUploader {
             const data = await resp.json();
 
             if (data.success) {
+                let statusMsg;
+                if (data.total_uploaded > 1) {
+                    statusMsg = `Successfully uploaded ${data.total_uploaded} items!`;
+                } else if (data.result.duplicate) {
+                    statusMsg = 'Already in library (duplicate)';
+                } else {
+                    statusMsg = 'Successfully uploaded!';
+                }
                 this.setStatus(
-                    data.result.duplicate
-                        ? 'Already in library (duplicate)'
-                        : 'Successfully uploaded!',
+                    statusMsg,
                     data.result.duplicate ? 'warning' : 'success'
                 );
                 this.addResult(data.result);
+                if (data.additional_results) {
+                    data.additional_results.forEach(r => this.addResult(r));
+                }
                 input.value = '';
                 this.onUploadComplete(data.result);
             } else {

--- a/frontend/url-uploader.js
+++ b/frontend/url-uploader.js
@@ -19,61 +19,33 @@ class UrlUploader {
         this.loadSupportedPlatforms();
     }
 
+    // NOTE: This render method uses innerHTML to build its own UI shell.
+    // All dynamic user content (filenames, URLs, platform names) injected
+    // later uses escapeHtml() or textContent -- see addResult() and
+    // loadSupportedPlatforms(). This initial template contains only
+    // static markup with no user-supplied data.
     render() {
-        this.container.innerHTML = `
-            <div class="url-uploader">
-                <div class="url-input-section">
-                    <h3 class="text-lg font-semibold mb-2 dark:text-white">Upload from URL</h3>
-                    <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-                        Paste a link from TikTok, Instagram, Facebook, Reddit, YouTube, Twitter, or any direct image URL
-                    </p>
-
-                    <div style="display: flex; flex-direction: column; gap: 0.5rem;">
-                        <input
-                            type="text"
-                            id="url-input"
-                            placeholder="https://www.tiktok.com/@user/video/..."
-                            class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                        />
-                        <button
-                            id="url-upload-btn"
-                            class="w-full px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                            style="display: flex; align-items: center; justify-content: center; gap: 0.5rem;"
-                        >
-                            <span id="url-btn-text">Upload</span>
-                            <svg id="url-spinner" class="hidden animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                            </svg>
-                        </button>
-                    </div>
-
-                    <div id="url-status" class="mt-2 text-sm hidden"></div>
-
-                    <div id="supported-platforms" class="mt-4 text-xs text-gray-400 dark:text-gray-500">
-                        Loading supported platforms...
-                    </div>
-                </div>
-
-                <div class="url-batch-section mt-6 hidden" id="batch-section">
-                    <h4 class="text-md font-semibold mb-2 dark:text-white">Batch Upload</h4>
-                    <textarea
-                        id="batch-urls"
-                        rows="4"
-                        placeholder="Paste multiple URLs, one per line..."
-                        class="w-full px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-white"
-                    ></textarea>
-                    <button
-                        id="batch-upload-btn"
-                        class="mt-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
-                    >
-                        Upload All
-                    </button>
-                </div>
-
-                <div id="url-results" class="mt-4 space-y-2"></div>
-            </div>
-        `;
+        this.container.innerHTML =
+            '<div class="url-uploader">'
+          + '<div class="card-header"><h3>Upload from URL</h3></div>'
+          + '<p class="text-sm text-secondary mb-3">Paste a link from TikTok, Instagram, Facebook, Reddit, YouTube, Twitter, or any direct image URL</p>'
+          + '<div style="display:flex;flex-direction:column;gap:8px;">'
+          + '<input type="text" id="url-input" placeholder="https://www.tiktok.com/@user/video/..." class="input" />'
+          + '<button id="url-upload-btn" class="btn btn--primary btn--full" style="display:flex;align-items:center;justify-content:center;gap:6px;">'
+          + '<span id="url-btn-text">Upload</span>'
+          + '<svg id="url-spinner" class="hidden animate-spin" width="18" height="18" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">'
+          + '<circle style="opacity:0.25;" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>'
+          + '<path style="opacity:0.75;" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>'
+          + '</svg></button></div>'
+          + '<div id="url-status" class="hidden mt-2 text-sm"></div>'
+          + '<div id="supported-platforms" class="platform-tags mt-3"><span class="text-xs text-tertiary">Loading platforms...</span></div>'
+          + '<div class="hidden mt-4" id="batch-section">'
+          + '<label class="form-label">Batch Upload</label>'
+          + '<textarea id="batch-urls" rows="4" placeholder="Paste multiple URLs, one per line..." class="input" style="font-family:var(--font-mono);font-size:0.8125rem;"></textarea>'
+          + '<button id="batch-upload-btn" class="btn btn--primary mt-2">Upload All</button>'
+          + '</div>'
+          + '<div id="url-results" class="mt-3 space-y-sm"></div>'
+          + '</div>';
     }
 
     attachEventListeners() {
@@ -121,13 +93,19 @@ class UrlUploader {
         try {
             const resp = await fetch(`${this.apiBase}/api/supported-platforms`);
             const data = await resp.json();
-
             const platformsDiv = this.container.querySelector('#supported-platforms');
-            const platformList = data.platforms.map(p =>
-                `<span class="inline-block px-2 py-1 bg-gray-100 dark:bg-gray-700 rounded mr-1 mb-1">${p}</span>`
-            ).join('');
-
-            platformsDiv.innerHTML = `Supported: ${platformList}`;
+            // Build platform tags using DOM methods (no innerHTML with user data)
+            platformsDiv.textContent = '';
+            const label = document.createElement('span');
+            label.className = 'text-xs text-tertiary';
+            label.textContent = 'Supported: ';
+            platformsDiv.appendChild(label);
+            data.platforms.forEach(function(p) {
+                const tag = document.createElement('span');
+                tag.className = 'platform-tag';
+                tag.textContent = p;
+                platformsDiv.appendChild(tag);
+            });
         } catch (error) {
             console.warn('Could not load supported platforms:', error);
         }
@@ -135,16 +113,14 @@ class UrlUploader {
 
     setStatus(message, type = 'info') {
         const statusDiv = this.container.querySelector('#url-status');
-        statusDiv.classList.remove('hidden', 'text-red-500', 'text-green-500', 'text-blue-500', 'text-yellow-500');
-
+        statusDiv.classList.remove('hidden');
         const colorMap = {
-            error: 'text-red-500',
-            success: 'text-green-500',
-            info: 'text-blue-500',
-            warning: 'text-yellow-500',
+            error: 'var(--red-text)',
+            success: 'var(--green-text)',
+            info: 'var(--blue-text)',
+            warning: 'var(--amber-text)',
         };
-
-        statusDiv.classList.add(colorMap[type] || 'text-blue-500');
+        statusDiv.style.color = colorMap[type] || colorMap.info;
         statusDiv.textContent = message;
     }
 
@@ -254,31 +230,38 @@ class UrlUploader {
 
     addResult(result) {
         const resultsDiv = this.container.querySelector('#url-results');
-
-        const statusColors = {
-            success: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200',
-            error: 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200',
-            duplicate: 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200',
-        };
-
         const status = result.duplicate ? 'duplicate' : result.status;
-        const colorClass = statusColors[status] || statusColors.error;
+        const badgeClass = status === 'duplicate' ? 'badge--amber' : status === 'success' ? 'badge--green' : 'badge--red';
 
+        // Build result element using DOM methods to avoid innerHTML with user data
         const resultEl = document.createElement('div');
-        resultEl.className = `p-3 rounded-lg ${colorClass} flex justify-between items-center`;
-        resultEl.innerHTML = `
-            <div>
-                <span class="font-medium">${this.escapeHtml(result.filename)}</span>
-                ${result.platform ? `<span class="ml-2 text-xs opacity-75">${result.platform}</span>` : ''}
-            </div>
-            <span class="px-2 py-1 rounded text-xs font-semibold uppercase">
-                ${result.duplicate ? 'Duplicate' : result.status}
-            </span>
-        `;
+        resultEl.className = 'upload-item';
+        resultEl.style.display = 'flex';
+        resultEl.style.alignItems = 'center';
+        resultEl.style.justifyContent = 'space-between';
 
+        const left = document.createElement('div');
+        left.style.minWidth = '0';
+        const nameSpan = document.createElement('span');
+        nameSpan.style.fontWeight = '500';
+        nameSpan.textContent = result.filename;
+        left.appendChild(nameSpan);
+        if (result.platform) {
+            const platSpan = document.createElement('span');
+            platSpan.className = 'text-xs text-secondary';
+            platSpan.style.marginLeft = '8px';
+            platSpan.textContent = result.platform;
+            left.appendChild(platSpan);
+        }
+
+        const badge = document.createElement('span');
+        badge.className = 'badge ' + badgeClass;
+        badge.textContent = result.duplicate ? 'Duplicate' : result.status;
+
+        resultEl.appendChild(left);
+        resultEl.appendChild(badge);
         resultsDiv.prepend(resultEl);
 
-        // Keep only last 10 results
         while (resultsDiv.children.length > 10) {
             resultsDiv.removeChild(resultsDiv.lastChild);
         }

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.3.3"
+VERSION = "1.3.4"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.3.1"
+VERSION = "1.3.2"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.2.9"
+VERSION = "1.3.0"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.3.0"
+VERSION = "1.3.1"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.3.4"
+VERSION = "1.3.5"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.3.2"
+VERSION = "1.3.3"


### PR DESCRIPTION
## Summary

- **Direct image URL downloads** (v1.3.0): Bypass yt-dlp for image files from i.redd.it, i.imgur.com, pbs.twimg.com, preview.redd.it, or any URL ending in an image extension. Downloads via httpx with magic-byte file type detection.
- **Reddit/Instagram extraction** (v1.3.1): Bypass yt-dlp for Reddit image posts (fixes HTTP 429) and Instagram image/carousel posts (fixes "No video formats found"). Fetches post JSON/API directly, supports multi-image galleries.
- **Cookie threading** (v1.3.2): Thread Instagram cookies through the full extraction pipeline. Harden CDN downloads (non-fatal HEAD pre-check). Hardened og:image regex for both attribute orderings.
- **oEmbed fallback** (v1.3.3): Instagram oEmbed fallback when og:image meta tags are absent on JS-rendered pages.
- **SSRF protection** (v1.3.4): Block direct image downloads targeting private/internal networks. Validates hostnames resolve to public IPs, blocks non-HTTP(S) schemes, validates redirect targets via httpx event hook.
- **UI redesign** (v1.3.4): Replace Tailwind CDN with custom styles.css. DM Sans typography. Consistent component system across all 4 pages. Mobile-responsive tables, headers, and forms. Dark mode via CSS variables.
- **Async hook crash fix** (v1.3.5): SSRF redirect validation hook was sync but httpx AsyncClient requires async -- all direct image downloads were crashing with TypeError.
- **Instagram story extraction** (v1.3.5): Story URLs now use private API flow (web_profile_info + reels_media) instead of failing through the shortcode-based extractor. Requires cookies.
- **Multi-item response** (v1.3.5): Single URL upload endpoint now returns `total_uploaded` count and `additional_results` list so the frontend can display all gallery/carousel items.
- **Immich brand colors** (v1.3.5): Accent color updated to Immich primary indigo (#4250af light / #accbfa dark). Applied to buttons, focus rings, platform tags, dropzone, and footer links.
- **Platform tags fix** (v1.3.5): CSS selector bug caused "Supported:" tags to render as unstyled run-together text. Tags now display as properly spaced accent-colored badges.

## Test plan

- [ ] Direct image URL download (e.g., i.redd.it link)
- [ ] Reddit image post extraction (single + gallery)
- [ ] Instagram image post extraction (single + carousel)
- [ ] Instagram story URL extraction (with cookies)
- [ ] Instagram oEmbed fallback (post without og:image)
- [ ] Multi-item post returns total_uploaded and additional_results in response
- [ ] SSRF blocked for private IPs (169.254.x.x, 10.x.x.x, 127.0.0.1)
- [ ] SSRF blocked for redirect to private IP
- [ ] All 4 pages render correctly on desktop and mobile
- [ ] Dark mode toggle works on all pages -- Immich indigo accent throughout
- [ ] Platform tags display as spaced badges (not run-together text)
- [ ] Docker build + start succeeds with v1.3.5 logged

Generated with [Claude Code](https://claude.com/claude-code)
