### PR TITLE
fix: accept any URL, harden Reddit paths (v1.6.2, v1.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.2] - 2026-04-15
+
+### Changed
+- URL upload no longer restricts to a hand-maintained platform allowlist. Any URL
+  is accepted; yt-dlp or gallery-dl attempts the download and the job fails
+  cleanly if neither tool can handle it.
+- `GET /api/supported-platforms` now returns an advisory list only; any URL is
+  accepted by the upload endpoint regardless of what this returns.
+- Removed `is_supported_url()`.
+
+### Fixed
+- Reddit `media?url=` redirect detection now tolerates trailing slashes
+  (`/media/` vs `/media`).
+- Reddit share links that resolve to an empty URL, the original URL, or another
+  `/s/` link now fail fast with a clear error instead of being passed to yt-dlp.
+- yt-dlp HTTP 429 responses surface as "Rate limited by source" instead of the
+  raw stderr.
+
+### Added
+- For unknown/generic URLs, gallery-dl is attempted as a last-resort fallback
+  after yt-dlp fails, widening coverage to anything either tool supports.
+
 ## [1.6.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.3] - 2026-04-15
+
+### Fixed
+- Reddit `media?url=` fallback in `download_from_url_multi` no longer fails with
+  `[Errno 2] No such file or directory` after yt-dlp's own failure path removed
+  the caller-owned temp dir. `download_from_url` now only deletes directories
+  it created itself.
+
 ## [1.6.2] - 2026-04-15
 
 ### Changed

--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -23,7 +23,6 @@ from .url_downloader import (
     download_from_url_multi,
     download_multiple_urls,
     cleanup_download,
-    is_supported_url,
     identify_platform,
     is_direct_image_url,
     SUPPORTED_PATTERNS,
@@ -217,7 +216,8 @@ def create_api_routes(config):
 
     @router.get("/supported-platforms", response_model=SupportedPlatformsResponse)
     async def get_supported_platforms():
-        """Get list of supported platforms for URL downloads"""
+        """Advisory list of platforms with dedicated routing/cookie handling.
+        Any URL is accepted by /upload/url; this list is examples only."""
         return SupportedPlatformsResponse(
             platforms=list(SUPPORTED_PATTERNS.keys()),
             examples={
@@ -227,7 +227,7 @@ def create_api_routes(config):
                 "youtube": "https://www.youtube.com/shorts/ABC123",
                 "twitter": "https://twitter.com/user/status/123456789",
                 "facebook": "https://www.facebook.com/reel/123456789",
-            }
+            },
         )
 
     @router.post("/upload/url", response_model=JobResponse)
@@ -240,17 +240,15 @@ def create_api_routes(config):
         Returns a job ID immediately. Poll /api/upload/url/status/{job_id} for results.
         """
         url = url_request.url.strip()
+        if not url:
+            raise HTTPException(status_code=400, detail="URL is required")
 
-        # Validate URL
         platform = identify_platform(url)
         direct_image = is_direct_image_url(url)
-        if not platform and not direct_image:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Unsupported URL. Supported platforms: {', '.join(SUPPORTED_PATTERNS.keys())}. Direct image URLs are also accepted."
-            )
-
-        logger.info("URL upload request: platform=%s direct_image=%s url=%s", platform, direct_image, url)
+        logger.info(
+            "URL upload request: platform=%s direct_image=%s url=%s",
+            platform or "generic", direct_image, url,
+        )
 
         job = create_job(url, url_request.album_name)
         httpx_client = request.app.state.httpx_client
@@ -389,15 +387,9 @@ def create_api_routes(config):
         if len(urls) > 10:
             raise HTTPException(status_code=400, detail="Maximum 10 URLs per request")
 
-        # Validate all URLs first and collect platforms
-        platforms = []
-        for url in urls:
-            if not is_supported_url(url):
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Unsupported URL: {url}"
-                )
-            platforms.append(identify_platform(url))  # None for direct image URLs
+        # Collect platforms for cookie selection; unknown URLs are allowed through
+        # and attempted by yt-dlp / gallery-dl.
+        platforms = [identify_platform(u) for u in urls]
 
         # Look up cookies - if all URLs are from the same platform, use cookies
         cookies_file = None

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -505,11 +505,6 @@ async def download_from_url(
     does not handle the URL or fails). Called by download_from_url_multi().
     """
     platform = identify_platform(url)
-    if not platform:
-        return DownloadResult(
-            success=False,
-            error=f"Unsupported URL. Supported platforms: {', '.join(SUPPORTED_PATTERNS.keys())}"
-        )
 
     # Create output directory
     if output_dir is None:
@@ -763,13 +758,17 @@ async def download_from_url_multi(
                 ) as client:
                     head_resp = await client.head(url, headers={"User-Agent": BROWSER_USER_AGENT})
                     resolved = str(head_resp.url)
-                    if resolved != url:
-                        logger.info("Resolved Reddit share link: %s -> %s", url, resolved)
-                        url = resolved
-                        parsed = urlparse(url)
+                    if not resolved or resolved == url or "/s/" in urlparse(resolved).path:
+                        return [DownloadResult(
+                            success=False,
+                            error=f"Reddit share link did not resolve to a post: {url}",
+                        )]
+                    logger.info("Resolved Reddit share link: %s -> %s", url, resolved)
+                    url = resolved
+                    parsed = urlparse(url)
 
             # Media wrapper (reddit.com/media?url=<encoded-image-url>)
-            if parsed.hostname and "reddit.com" in parsed.hostname and parsed.path == "/media":
+            if parsed.hostname and "reddit.com" in parsed.hostname and parsed.path.rstrip("/") == "/media":
                 params = parse_qs(parsed.query)
                 if "url" in params:
                     embedded_url = unquote(params["url"][0])
@@ -814,12 +813,30 @@ async def download_from_url_multi(
 
     # If yt-dlp failed on a reddit.com/media?url= redirect, extract the embedded image URL
     if not result.success and result.error and "reddit.com/media?url=" in result.error:
-        import re
         match = re.search(r'reddit\.com/media\?url=(https?%3A%2F%2F[^\s"\']+)', result.error)
         if match:
             embedded_url = unquote(match.group(1))
             logger.info("Extracting embedded image URL from yt-dlp Reddit media error: %s", embedded_url)
             result = await download_direct_image(embedded_url, output_dir)
+
+    # Surface rate-limit failures with a clearer message
+    if not result.success and result.error and "HTTP Error 429" in result.error:
+        result = DownloadResult(
+            success=False,
+            error=f"Rate limited by source ({platform or 'site'}); try again later",
+        )
+
+    # Final fallback: if we haven't already, try gallery-dl for unknown URLs
+    if not result.success and platform is None:
+        logger.info("yt-dlp failed for unknown URL %s; trying gallery-dl as last resort", url)
+        gdl_results = await extract_via_gallery_dl(
+            url, output_dir, cookies_file, platform=None, settings=settings,
+        )
+        if gdl_results:
+            return gdl_results
+        logger.warning(
+            "Both yt-dlp and gallery-dl failed for %s: %s", url, result.error,
+        )
 
     return [result]
 

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import tempfile
 import asyncio
 import hashlib
@@ -507,6 +508,7 @@ async def download_from_url(
     platform = identify_platform(url)
 
     # Create output directory
+    owned_output_dir = output_dir is None
     if output_dir is None:
         output_dir = tempfile.mkdtemp(prefix="immich_drop_")
 
@@ -591,9 +593,10 @@ async def download_from_url(
         if process.returncode != 0:
             error_msg = stderr.decode().strip() if stderr else "Unknown error"
             logger.error("yt-dlp failed (exit %d): %s", process.returncode, error_msg)
-            # Clean up temp dir if we created it
-            if output_dir and output_dir.startswith(tempfile.gettempdir()):
-                import shutil
+            # Only clean up the temp dir if we created it ourselves; callers
+            # that passed their own output_dir may still need it (e.g. for the
+            # reddit media?url= fallback in download_from_url_multi).
+            if owned_output_dir and output_dir.startswith(tempfile.gettempdir()):
                 shutil.rmtree(output_dir, ignore_errors=True)
             return DownloadResult(
                 success=False,
@@ -817,6 +820,7 @@ async def download_from_url_multi(
         if match:
             embedded_url = unquote(match.group(1))
             logger.info("Extracting embedded image URL from yt-dlp Reddit media error: %s", embedded_url)
+            os.makedirs(output_dir, exist_ok=True)
             result = await download_direct_image(embedded_url, output_dir)
 
     # Surface rate-limit failures with a clearer message

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.6.2"
+VERSION = "1.6.3"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.6.1"
+VERSION = "1.6.2"


### PR DESCRIPTION
## Summary

### v1.6.2
- Drop URL host allowlist on `/upload/url` and batch endpoint; yt-dlp and gallery-dl decide what they can handle.
- `/api/supported-platforms` kept as advisory examples (no UI changes).
- Reddit share links that resolve to empty/self/another `/s/` link fail fast.
- `reddit.com/media?url=` detection tolerates trailing slashes.
- yt-dlp `HTTP Error 429` surfaces as "Rate limited by source".
- For unknown URLs, gallery-dl runs as a last-resort fallback after yt-dlp.

### v1.6.3 (follow-up fix found in post-deploy logs)
- `download_from_url` no longer deletes a caller-owned `output_dir` on yt-dlp failure. This was breaking the `reddit.com/media?url=` stderr-regex fallback: yt-dlp cleanup removed the shared temp dir, then `download_direct_image` fetched the image via httpx but could not write it ("[Errno 2] No such file or directory").

## Version
1.6.3 (tagged `ttlequals0/immich-drop:1.6.3` and `:latest`)

## Test plan
- [x] Imports clean (`python -c "from app import api_routes, url_downloader"`)
- [x] Docker image built + pushed
- [x] Deployed via Portainer webhook
- [ ] Retry a Reddit `/s/` share link that resolves to an image-only post — expect `status=completed`, no `[Errno 2]` error in Loki
- [ ] Vimeo or other previously-unsupported URL — expect job created, no 400