### PR TITLE
chore: release v1.7.1 (Dependabot follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.7.1] - 2026-04-25
+
+### Dependencies (auto-bumped via Dependabot)
+- Group `python-deps`: anyio 4.10.0 -> 4.13.0, charset-normalizer 3.4.3 ->
+  3.4.7, click 8.2.1 -> 8.3.3, httptools 0.6.4 -> 0.7.1, idna 3.10 -> 3.13,
+  pydantic 2.11.7 -> 2.13.3, pydantic-core 2.33.2 -> 2.46.3, PyYAML 6.0.2 ->
+  6.0.3, requests 2.33.0 -> 2.33.1, uvicorn 0.35.0 -> 0.46.0,
+  watchfiles 1.1.0 -> 1.1.1 (PR #13).
+- starlette 0.49.1 -> 1.0.0 (PR #14).
+- certifi 2025.8.3 -> 2026.4.22 (PR #15).
+- websockets 15.0.1 -> 16.0 (PR #16).
+
 ## [1.7.0] - 2026-04-25
 
 ### Security

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.7.0"
+VERSION = "1.7.1"


### PR DESCRIPTION
## Summary

Version bump only. Cuts a release with the four Dependabot bumps that merged after v1.7.0:

- **python-deps group (#13)**: anyio 4.10.0 -> 4.13.0, charset-normalizer 3.4.3 -> 3.4.7, click 8.2.1 -> 8.3.3, httptools 0.6.4 -> 0.7.1, idna 3.10 -> 3.13, pydantic 2.11.7 -> 2.13.3, pydantic-core 2.33.2 -> 2.46.3, PyYAML 6.0.2 -> 6.0.3, requests 2.33.0 -> 2.33.1, uvicorn 0.35.0 -> 0.46.0, watchfiles 1.1.0 -> 1.1.1
- **starlette (#14)**: 0.49.1 -> 1.0.0
- **certifi (#15)**: 2025.8.3 -> 2026.4.22
- **websockets (#16)**: 15.0.1 -> 16.0

No application code changes.

## Version
1.7.1

## Test plan
- [x] `docker build --platform linux/amd64` succeeds
- [x] Container boots, `/api/config` reports `1.7.1`
- [x] `trivy image --severity HIGH,CRITICAL` -> 6 HIGH OS (unfixed in trixie) + 1 HIGH Python (curl_cffi, blocked by yt-dlp pin) — same floor as 1.7.0
- [x] Image `ttlequals0/immich-drop:1.7.1` and `:latest` pushed to Docker Hub
- [x] Portainer webhook fired (HTTP 204)
- [ ] Production smoke after deploy