### PR TITLE
Release 1.8.0: Immich v3 API compatibility, upload client unification, cleanups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,6 @@ screenshot.png
 .env
 *.env
 agent.md
+docs/
+CHANGELOG.md
+CLAUDE.md

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@ PORT=8080
 # Immich connection (include /api)
 IMMICH_BASE_URL=http://REPLACE_ME:2283/api
 IMMICH_API_KEY=ADD-YOUR-API-KEY   # needs: asset.upload; for albums also: album.create, album.read, albumAsset.create
-MAX_CONCURRENT=3
 
 # Public uploader page (optional) — disabled by default
 PUBLIC_UPLOAD_PAGE_ENABLED=TRUE
@@ -21,7 +20,7 @@ STATE_DB=./data/state.db
 
 # Session and security
 SESSION_SECRET=SET-A-STRONG-RANDOM-VALUE
-LOG_LEVEL=DEBUG
+LOG_LEVEL=INFO
 
 # Chunked uploads (to work around 100MB proxy limits)
 # Enable to send files in chunks from browser to this service; the service reassembles and forwards to Immich.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,69 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.0] - 2026-07-10
+
+### Fixed
+- Immich v3 API compatibility: uploads to Immich 3.x failed with 400
+  "Validation failed". The v3 AssetMediaCreateDto no longer accepts
+  deviceAssetId, deviceId, or originalFileName, and its Zod validation rejects
+  unknown fields; those fields are no longer sent. The synthetic
+  device-asset-id is still used for the local dedupe cache only.
+- Immich v3 requires fileCreatedAt/fileModifiedAt in ISO-8601 with an explicit
+  timezone offset; naive EXIF/mtime timestamps are now normalized to UTC.
+- URL-download uploads reported duplicates incorrectly: the code read a
+  non-existent "duplicate" field from the upload response instead of
+  status == "duplicate".
+- Invites created with only an album name never resolved the album: the
+  get_or_create_album coroutine was not awaited (stored a coroutine object
+  instead of an album id).
+- Reachability ping no longer probes /server-info (removed in v3); it now uses
+  /server/ping and /server/version.
+- Immich error responses (now Zod-shaped in v3) are parsed into readable
+  messages instead of raw JSON blobs.
+
+### Changed
+- Unified three separate upload-to-Immich implementations (whole-file, chunked
+  complete, URL/batch/iOS paths) into one async client
+  (app/immich_client.py) using the shared httpx client. Removes blocking
+  requests calls from async handlers; requests and requests-toolbelt
+  dependencies dropped.
+- Centralized SQLite access in app/db.py; all tables (uploads, invites,
+  platform_cookies, upload_events) are created once at startup instead of per
+  request (upload_events was previously CREATE TABLE'd on every upload).
+- Chunked upload completion streams parts into a single file and verifies all
+  parts before consuming them, instead of buffering the whole file in memory
+  twice.
+- Expired URL-download jobs are cleaned up by a background task instead of
+  only when a client polls job status.
+- Third-party debug logging (PIL, python_multipart, httpcore, httpx, urllib3,
+  websockets) is capped at WARNING so LOG_LEVEL=DEBUG no longer floods logs
+  with EXIF-tag and multipart-parser noise; .env.example default is now INFO.
+- CORS middleware no longer combines wildcard origins with credentials.
+- Favicon is read from disk once at startup instead of on every request.
+- Theme choice (from the new auto light/dark mode, PR #44) now persists in
+  localStorage across page loads.
+- Invite create form (PR #50) only clears its fields after successful
+  creation.
+- Docker image: requirements.txt path aligned with WORKDIR, redundant separate
+  python-multipart install removed, docs/CHANGELOG excluded from build
+  context.
+
+### Removed
+- Dead code: unused db_get_cookie (cookie_manager), is_supported_url
+  (url_downloader), unused download_from_url import, MAX_CONCURRENT setting
+  (never referenced), dead retry handler and unused escapeHtml in the
+  frontend, commented-out login gate, duplicate pbkdf2 hasher definitions.
+
+### Merged
+- Dependabot #55 (13 python-deps updates incl. starlette 1.3.1 and
+  python-multipart 0.0.32, resolving Dependabot alerts 16-21) and #53
+  (yt-dlp 2026.7.4, gallery-dl 1.32.5). #36/#37/#38 superseded by #55.
+- Community PRs by aidenjbass: #44 auto light/dark theme, #45 mobile
+  formatting, #46 social media section toggle, #47 hide back-to-uploader
+  button when public uploads disabled, #48 album name fix, #50 clear invite
+  form after creation, #51 human readable byte sizes.
+
 ## [1.7.2] - 2026-06-14
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,9 @@ COPY --from=mwader/static-ffmpeg:7.1 /ffmpeg /usr/local/bin/ffmpeg
 COPY --from=mwader/static-ffmpeg:7.1 /ffprobe /usr/local/bin/ffprobe
 
 # Install Python deps
-COPY requirements.txt /app/requirements.txt
+COPY requirements.txt /immich_drop/requirements.txt
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && pip install --no-cache-dir -r /app/requirements.txt \
-    && pip install --no-cache-dir python-multipart
+    && pip install --no-cache-dir -r /immich_drop/requirements.txt
 
 # Copy app code
 COPY . /immich_drop

--- a/app/api_routes.py
+++ b/app/api_routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, UploadFile, File, Form, Background
 from fastapi.responses import JSONResponse
 from typing import List, Optional
 from pydantic import BaseModel
-from datetime import datetime
+from datetime import datetime, timezone
 import hashlib
 import httpx
 import os
@@ -18,8 +18,8 @@ import asyncio
 
 logger = logging.getLogger("immich_drop.api_routes")
 
+from . import immich_client
 from .url_downloader import (
-    download_from_url,
     download_from_url_multi,
     download_multiple_urls,
     cleanup_download,
@@ -29,7 +29,7 @@ from .url_downloader import (
 )
 from .cookie_manager import get_cookie_file_for_platform
 from .utils import detect_file_type
-from .job_manager import create_job, get_job, update_job, cleanup_expired
+from .job_manager import create_job, get_job, update_job
 
 
 router = APIRouter(prefix="/api", tags=["api"])
@@ -110,52 +110,35 @@ async def upload_to_immich(
     content_type: str,
     config,  # Config object from main app
     httpx_client: httpx.AsyncClient,  # Shared httpx client
-    device_id: str = "immich-drop-url",
-    file_created_at: Optional[str] = None,
+    file_created_at: Optional[datetime] = None,
 ) -> UploadResult:
     """Upload a file to Immich server"""
     sha1 = hashlib.sha1(file_content).hexdigest()
-    now = file_created_at or (datetime.utcnow().isoformat() + "Z")
-    device_asset_id = f"{device_id}-{sha1}"
-
-    try:
-        resp = await httpx_client.post(
-            f"{config.normalized_base_url}/assets",
-            files={"assetData": (filename, file_content, content_type)},
-            data={
-                "deviceAssetId": device_asset_id,
-                "deviceId": device_id,
-                "fileCreatedAt": now,
-                "fileModifiedAt": now,
-                "isFavorite": "false",
-            },
-            headers={
-                "x-api-key": config.immich_api_key,
-                "x-immich-checksum": sha1,
-            },
-            timeout=300.0,
-        )
-
-        if resp.status_code in (200, 201):
-            result = resp.json()
-            return UploadResult(
-                filename=filename,
-                status="success",
-                asset_id=result.get("id"),
-                duplicate=result.get("duplicate", False),
-            )
-        else:
-            return UploadResult(
-                filename=filename,
-                status="error",
-                error=f"Immich returned {resp.status_code}: {resp.text[:200]}",
-            )
-    except Exception as e:
+    headers = {"x-api-key": config.immich_api_key}
+    outcome = await immich_client.upload_asset(
+        httpx_client,
+        config.normalized_base_url,
+        headers,
+        file_bytes=file_content,
+        filename=filename,
+        content_type=content_type,
+        checksum=sha1,
+        created_at=file_created_at,
+        modified_at=file_created_at,
+        timeout=300.0,
+    )
+    if outcome.ok:
         return UploadResult(
             filename=filename,
-            status="error",
-            error=str(e),
+            status="success",
+            asset_id=outcome.asset_id,
+            duplicate=outcome.status == "duplicate",
         )
+    return UploadResult(
+        filename=filename,
+        status="error",
+        error=f"Immich returned {outcome.status_code}: {outcome.error}" if outcome.status_code else (outcome.error or "upload failed"),
+    )
 
 
 async def add_asset_to_album(
@@ -166,45 +149,14 @@ async def add_asset_to_album(
 ) -> bool:
     """Add an asset to an album (creates album if needed)"""
     headers = {"x-api-key": config.immich_api_key}
-
-    # Find or create album
-    albums_resp = await httpx_client.get(
-        f"{config.normalized_base_url}/albums",
-        headers=headers,
-        timeout=30.0,
+    album_id = await immich_client.find_or_create_album(
+        httpx_client, config.normalized_base_url, headers, album_name
     )
-
-    album_id = None
-    if albums_resp.status_code == 200:
-        albums = albums_resp.json()
-        for album in albums:
-            if album.get("albumName") == album_name:
-                album_id = album.get("id")
-                break
-
-    # Create album if not found
-    if not album_id:
-        create_resp = await httpx_client.post(
-            f"{config.normalized_base_url}/albums",
-            headers=headers,
-            json={"albumName": album_name},
-            timeout=30.0,
-        )
-        if create_resp.status_code in (200, 201):
-            album_id = create_resp.json().get("id")
-
     if not album_id:
         return False
-
-    # Add asset to album
-    add_resp = await httpx_client.put(
-        f"{config.normalized_base_url}/albums/{album_id}/assets",
-        headers=headers,
-        json={"ids": [asset_id]},
-        timeout=30.0,
+    return await immich_client.add_to_album(
+        httpx_client, config.normalized_base_url, headers, album_id, asset_id
     )
-
-    return add_resp.status_code in (200, 201)
 
 
 # ============================================================================
@@ -301,7 +253,7 @@ def create_api_routes(config):
                     if download_result.metadata:
                         timestamp = download_result.metadata.get("timestamp")
                         if timestamp:
-                            file_created_at = datetime.fromtimestamp(timestamp).isoformat() + "Z"
+                            file_created_at = datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
                     upload_result = await upload_to_immich(
                         file_content=file_content,
@@ -309,7 +261,6 @@ def create_api_routes(config):
                         content_type=download_result.content_type,
                         config=config,
                         httpx_client=httpx_client,
-                        device_id=f"immich-drop-{source_label}",
                         file_created_at=file_created_at,
                     )
                     upload_result.platform = source_label
@@ -352,7 +303,6 @@ def create_api_routes(config):
     @router.get("/upload/url/status/{job_id}", response_model=JobStatusResponse)
     async def get_upload_status(job_id: str):
         """Poll for the status of an async URL upload job."""
-        cleanup_expired()
         job = get_job(job_id)
         if not job:
             raise HTTPException(status_code=404, detail="Job not found or expired")
@@ -423,7 +373,7 @@ def create_api_routes(config):
                 if download_result.metadata:
                     timestamp = download_result.metadata.get("timestamp")
                     if timestamp:
-                        file_created_at = datetime.fromtimestamp(timestamp).isoformat() + "Z"
+                        file_created_at = datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
                 upload_result = await upload_to_immich(
                     file_content=file_content,
@@ -431,7 +381,6 @@ def create_api_routes(config):
                     content_type=download_result.content_type,
                     config=config,
                     httpx_client=httpx_client,
-                    device_id=f"immich-drop-{source_label}",
                     file_created_at=file_created_at,
                 )
                 upload_result.platform = source_label
@@ -490,8 +439,7 @@ def create_api_routes(config):
                 content_type=content_type,
                 config=config,
                 httpx_client=httpx_client,
-                device_id="ios-shortcut",
-            )
+                )
 
             # Add to album
             target_album = album_name or getattr(config, 'album_name', None)
@@ -532,7 +480,6 @@ def create_api_routes(config):
             content_type=content_type,
             config=config,
             httpx_client=httpx_client,
-            device_id="ios-shortcut",
         )
 
         target_album = album_name or getattr(config, 'album_name', None)
@@ -596,7 +543,6 @@ def create_api_routes(config):
             content_type=content_type,
             config=config,
             httpx_client=httpx_client,
-            device_id="ios-shortcut-base64",
         )
 
         target_album = upload_request.album_name or getattr(config, 'album_name', None)

--- a/app/app.py
+++ b/app/app.py
@@ -11,20 +11,18 @@ Immich Drop Uploader – Backend (FastAPI, simplified)
 from __future__ import annotations
 
 import asyncio
+import binascii
 import io
 import json
 import hashlib
 import os
 import re
-import sqlite3
-from contextlib import asynccontextmanager
-from datetime import datetime
+from contextlib import asynccontextmanager, suppress
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
 import httpx
-import requests
-from requests_toolbelt.multipart.encoder import MultipartEncoder, MultipartEncoderMonitor
 import logging
 from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisconnect, Request, Form
 from fastapi.responses import HTMLResponse, JSONResponse, FileResponse, RedirectResponse, Response
@@ -39,6 +37,9 @@ except Exception:
     qrcode = None
 
 from app.config import Settings, load_settings
+from app import db, immich_client
+from app.immich_client import to_immich_iso
+from app.job_manager import cleanup_expired
 from version import VERSION
 
 
@@ -49,17 +50,30 @@ async def lifespan(app: FastAPI):
     logger.info(f"Starting immich-drop v{VERSION}")
     # Startup: create shared httpx client for connection pooling
     app.state.httpx_client = httpx.AsyncClient(timeout=30.0)
+
+    async def _job_cleanup_loop():
+        while True:
+            await asyncio.sleep(60)
+            with suppress(Exception):
+                cleanup_expired()
+
+    cleanup_task = asyncio.create_task(_job_cleanup_loop())
     yield
-    # Shutdown: close the shared client
+    # Shutdown: stop background work and close the shared client
+    cleanup_task.cancel()
+    with suppress(asyncio.CancelledError):
+        await cleanup_task
     await app.state.httpx_client.aclose()
 
 
 # ---- App & static ----
 app = FastAPI(title="Immich Drop Uploader (Python)", lifespan=lifespan)
+# Wildcard origins must not be combined with credentials; the frontend is
+# same-origin and API clients (iOS Shortcuts) do not use cookies.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -69,6 +83,10 @@ SETTINGS: Settings = load_settings()
 
 # Basic logging setup using settings
 logging.basicConfig(level=SETTINGS.log_level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+# Third-party libraries log large volumes at DEBUG; keep them at WARNING
+# regardless of the app LOG_LEVEL.
+for _noisy in ("PIL", "python_multipart", "httpcore", "httpx", "urllib3", "websockets", "charset_normalizer"):
+    logging.getLogger(_noisy).setLevel(logging.WARNING)
 logger = logging.getLogger("immich_drop")
 
 # Cookie-based session for short-lived auth token storage (no persistence)
@@ -83,7 +101,7 @@ api_router = create_api_routes(SETTINGS)
 app.include_router(api_router)
 
 # Chunk upload storage
-CHUNK_ROOT = "/data/chunks"
+CHUNK_ROOT = os.getenv("CHUNK_DIR", "/data/chunks")
 try:
     os.makedirs(CHUNK_ROOT, exist_ok=True)
 except Exception:
@@ -101,31 +119,15 @@ def reset_album_cache() -> None:
     ALBUM_ID = None
 
 # ---------- DB (local dedupe cache) ----------
+# All tables (uploads, invites, platform_cookies, upload_events) are created
+# once at startup in db.init_db().
 
-def db_init() -> None:
-    """Create the local SQLite table used for duplicate checks (idempotent)."""
-    conn = sqlite3.connect(SETTINGS.state_db)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        CREATE TABLE IF NOT EXISTS uploads (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            checksum TEXT UNIQUE,
-            filename TEXT,
-            size INTEGER,
-            device_asset_id TEXT,
-            immich_asset_id TEXT,
-            created_at TEXT,
-            inserted_at TEXT DEFAULT CURRENT_TIMESTAMP
-        );
-        """
-    )
-    conn.commit()
-    conn.close()
+db.configure(SETTINGS.state_db)
+db.init_db()
 
 def db_lookup_checksum(checksum: str) -> Optional[dict]:
     """Return a record for the given checksum if seen before (None if not)."""
-    conn = sqlite3.connect(SETTINGS.state_db)
+    conn = db.connect()
     cur = conn.cursor()
     cur.execute("SELECT checksum, immich_asset_id FROM uploads WHERE checksum = ?", (checksum,))
     row = cur.fetchone()
@@ -136,7 +138,7 @@ def db_lookup_checksum(checksum: str) -> Optional[dict]:
 
 def db_lookup_device_asset(device_asset_id: str) -> bool:
     """True if a deviceAssetId has been uploaded by this service previously."""
-    conn = sqlite3.connect(SETTINGS.state_db)
+    conn = db.connect()
     cur = conn.cursor()
     cur.execute("SELECT 1 FROM uploads WHERE device_asset_id = ?", (device_asset_id,))
     row = cur.fetchone()
@@ -145,7 +147,7 @@ def db_lookup_device_asset(device_asset_id: str) -> bool:
 
 def db_insert_upload(checksum: str, filename: str, size: int, device_asset_id: str, immich_asset_id: Optional[str], created_at: str) -> None:
     """Insert a newly-uploaded asset into the local cache (ignore on duplicates)."""
-    conn = sqlite3.connect(SETTINGS.state_db)
+    conn = db.connect()
     cur = conn.cursor()
     cur.execute(
         "INSERT OR IGNORE INTO uploads (checksum, filename, size, device_asset_id, immich_asset_id, created_at) VALUES (?,?,?,?,?,?)",
@@ -153,8 +155,6 @@ def db_insert_upload(checksum: str, filename: str, size: int, device_asset_id: s
     )
     conn.commit()
     conn.close()
-
-db_init()
 
 # ---------- WebSocket hub ----------
 
@@ -310,55 +310,17 @@ async def get_or_create_album(request: Optional[Request] = None, album_name_over
         if album_name_override is None and ALBUM_ID:
             return ALBUM_ID
 
-        try:
-            # Use shared httpx client from app state
-            client = app.state.httpx_client
-            # First, try to find existing album
-            url = f"{SETTINGS.normalized_base_url}/albums"
-            r = await client.get(url, headers=immich_headers(request), timeout=10.0)
-
-            if r.status_code == 200:
-                albums = r.json()
-                for album in albums:
-                    if album.get("albumName") == album_name:
-                        found_id = album.get("id")
-                        if album_name_override is None:
-                            ALBUM_ID = found_id
-                            logger.info(f"Found existing album '%s' with ID: %s", album_name, ALBUM_ID)
-                            return ALBUM_ID
-                        else:
-                            return found_id
-            elif r.status_code >= 500:
-                # Server error from Immich - do not attempt to create album
-                # to avoid creating duplicates when server is having issues
-                logger.warning("Immich returned %s when listing albums, skipping album assignment", r.status_code)
-                return None
-
-            # Album doesn't exist, create it
-            create_url = f"{SETTINGS.normalized_base_url}/albums"
-            payload = {
-                "albumName": album_name,
-                "description": "Auto-created album for Immich Drop uploads"
-            }
-            r = await client.post(create_url, headers={**immich_headers(request), "Content-Type": "application/json"},
-                              json=payload, timeout=10.0)
-
-            if r.status_code in (200, 201):
-                data = r.json()
-                new_id = data.get("id")
-                if album_name_override is None:
-                    ALBUM_ID = new_id
-                    logger.info("Created new album '%s' with ID: %s", album_name, ALBUM_ID)
-                    return ALBUM_ID
-                else:
-                    logger.info("Created new album '%s' with ID: %s", album_name, new_id)
-                    return new_id
-            else:
-                logger.warning("Failed to create album: %s - %s", r.status_code, r.text)
-        except Exception as e:
-            logger.exception("Error managing album: %s", e)
-
-        return None
+        found_id = await immich_client.find_or_create_album(
+            app.state.httpx_client,
+            SETTINGS.normalized_base_url,
+            immich_headers(request),
+            album_name,
+            description="Auto-created album for Immich Drop uploads",
+        )
+        if found_id and album_name_override is None:
+            ALBUM_ID = found_id
+            logger.info("Resolved album '%s' to ID: %s", album_name, ALBUM_ID)
+        return found_id
 
 async def add_asset_to_album(asset_id: str, request: Optional[Request] = None, album_id_override: Optional[str] = None, album_name_override: Optional[str] = None) -> bool:
     """Add an asset to the configured album. Returns True on success."""
@@ -367,58 +329,21 @@ async def add_asset_to_album(asset_id: str, request: Optional[Request] = None, a
         album_id = await get_or_create_album(request=request, album_name_override=album_name_override)
     if not album_id or not asset_id:
         return False
-
-    try:
-        # Use shared httpx client from app state
-        client = app.state.httpx_client
-        url = f"{SETTINGS.normalized_base_url}/albums/{album_id}/assets"
-        payload = {"ids": [asset_id]}
-        r = await client.put(url, headers={**immich_headers(request), "Content-Type": "application/json"},
-                         json=payload, timeout=10.0)
-
-        if r.status_code == 200:
-            results = r.json()
-            # Check if any result indicates success
-            for result in results:
-                if result.get("success"):
-                    return True
-                elif result.get("error") == "duplicate":
-                    # Asset already in album, consider it success
-                    return True
-        return False
-    except Exception as e:
-        logger.exception("Error adding asset to album: %s", e)
-        return False
+    return await immich_client.add_to_album(
+        app.state.httpx_client, SETTINGS.normalized_base_url, immich_headers(request), album_id, asset_id
+    )
 
 async def immich_ping() -> bool:
     """Best-effort reachability check against a few Immich endpoints."""
     if not SETTINGS.immich_api_key:
         return False
-    base = SETTINGS.normalized_base_url
-    # Use shared httpx client from app state
-    client = app.state.httpx_client
-    for path in ("/server-info", "/server/version", "/users/me"):
-        try:
-            r = await client.get(f"{base}{path}", headers=immich_headers(), timeout=4.0)
-            if 200 <= r.status_code < 400:
-                return True
-        except Exception:
-            continue
-    return False
+    return await immich_client.ping(app.state.httpx_client, SETTINGS.normalized_base_url, immich_headers())
 
 async def immich_bulk_check(checks: List[dict]) -> Dict[str, dict]:
     """Try Immich bulk upload check; return map id->result (or empty on failure)."""
-    try:
-        # Use shared httpx client from app state
-        client = app.state.httpx_client
-        url = f"{SETTINGS.normalized_base_url}/assets/bulk-upload-check"
-        r = await client.post(url, headers=immich_headers(), json={"assets": checks}, timeout=10.0)
-        if r.status_code == 200:
-            results = r.json().get("results", [])
-            return {x["id"]: x for x in results}
-    except Exception:
-        pass
-    return {}
+    return await immich_client.bulk_upload_check(
+        app.state.httpx_client, SETTINGS.normalized_base_url, immich_headers(), checks
+    )
 
 async def send_progress(session_id: str, item_id: str, status: str, progress: int = 0, message: str = "", response_id: Optional[str] = None) -> None:
     """Push a progress update over WebSocket for one queue item."""
@@ -451,13 +376,17 @@ async def menu_page(request: Request) -> HTMLResponse:
         return RedirectResponse(url="/login")
     return FileResponse(os.path.join(FRONTEND_DIR, "menu.html"))
 
+try:
+    with open(os.path.join(FRONTEND_DIR, "favicon.png"), "rb") as _f:
+        _FAVICON_BYTES: Optional[bytes] = _f.read()
+except Exception:
+    _FAVICON_BYTES = None
+
 @app.get("/favicon.ico")
 async def favicon() -> Response:
     """Serve favicon from /static/favicon.png if present (avoids 404 noise)."""
-    path = os.path.join(FRONTEND_DIR, "favicon.png")
-    if os.path.exists(path):
-        with open(path, "rb") as f:
-            return Response(content=f.read(), media_type="image/png")
+    if _FAVICON_BYTES:
+        return Response(content=_FAVICON_BYTES, media_type="image/png")
     return Response(status_code=204)
 
 @app.post("/api/ping")
@@ -517,28 +446,154 @@ async def ws_endpoint(ws: WebSocket) -> None:
     finally:
         await hub.disconnect(session_id, ws)
 
-@app.post("/api/upload")
-async def api_upload(
+# ---------- Upload core (shared by whole-file and chunked paths) ----------
+
+def check_invite_for_upload(request: Request, invite_token: str, session_id: str):
+    """Validate an invite token for an upload attempt.
+
+    Returns (error, album_id, album_name) where error is
+    (ws_message, error_key, http_status) or None when the invite is usable.
+    """
+    try:
+        conn = db.connect()
+        cur = conn.cursor()
+        cur.execute("SELECT token, album_id, album_name, max_uses, used_count, expires_at, COALESCE(claimed,0), claimed_by_session, password_hash, COALESCE(disabled,0) FROM invites WHERE token = ?", (invite_token,))
+        row = cur.fetchone()
+        conn.close()
+    except Exception as e:
+        logger.exception("Invite lookup error: %s", e)
+        row = None
+    if not row:
+        return ("Invalid invite token", "invalid_invite", 403), None, None
+    _, album_id, album_name, max_uses, used_count, expires_at, claimed, claimed_by_session, password_hash, disabled = row
+    # Admin deactivation check
+    try:
+        if int(disabled) == 1:
+            return ("Invite disabled", "invite_disabled", 403), None, None
+    except Exception:
+        pass
+    # If invite requires password, ensure this session is authorized
+    if password_hash:
+        try:
+            ia = request.session.get("inviteAuth") or {}
+            if not ia.get(invite_token):
+                return ("Password required", "invite_password_required", 403), None, None
+        except Exception:
+            return ("Password required", "invite_password_required", 403), None, None
+    # Expiry check
+    if expires_at:
+        try:
+            if datetime.utcnow() > datetime.fromisoformat(expires_at):
+                return ("Invite expired", "invite_expired", 403), None, None
+        except Exception:
+            pass
+    # One-time claim or multi-use enforcement
+    try:
+        max_uses_int = int(max_uses) if max_uses is not None else -1
+    except Exception:
+        max_uses_int = -1
+    if max_uses_int == 1:
+        if claimed:
+            # Allow same session to continue; block different sessions
+            if claimed_by_session and claimed_by_session != session_id:
+                return ("Invite already used", "invite_claimed", 403), None, None
+        else:
+            # Atomically claim the one-time invite to prevent concurrent use
+            try:
+                connc = db.connect()
+                curc = connc.cursor()
+                curc.execute(
+                    "UPDATE invites SET claimed = 1, claimed_at = CURRENT_TIMESTAMP, claimed_by_session = ? WHERE token = ? AND (claimed IS NULL OR claimed = 0)",
+                    (session_id, invite_token)
+                )
+                connc.commit()
+                changed = connc.total_changes
+                connc.close()
+            except Exception as e:
+                logger.exception("Invite claim failed: %s", e)
+                return ("Invite claim failed", "invite_claim_failed", 500), None, None
+            if changed == 0:
+                # Someone else just claimed; re-check owner
+                try:
+                    conn2 = db.connect()
+                    cur2 = conn2.cursor()
+                    cur2.execute("SELECT claimed_by_session FROM invites WHERE token = ?", (invite_token,))
+                    owner_row = cur2.fetchone()
+                    conn2.close()
+                    owner = owner_row[0] if owner_row else None
+                except Exception:
+                    owner = None
+                if not owner or owner != session_id:
+                    return ("Invite already used", "invite_claimed", 403), None, None
+    else:
+        # Usage check for multi-use (max_uses < 0 => indefinite)
+        if (used_count or 0) >= (max_uses_int if max_uses_int >= 0 else 10**9):
+            return ("Invite already used up", "invite_exhausted", 403), None, None
+    return None, album_id, album_name
+
+def increment_invite_usage(invite_token: str) -> None:
+    """Bump used_count after a successful upload (one-time stays at 1)."""
+    try:
+        conn = db.connect()
+        cur = conn.cursor()
+        cur.execute("SELECT max_uses FROM invites WHERE token = ?", (invite_token,))
+        row_mu = cur.fetchone()
+        try:
+            mx = int(row_mu[0]) if row_mu and row_mu[0] is not None else None
+        except Exception:
+            mx = None
+        if mx == 1:
+            cur.execute("UPDATE invites SET used_count = 1 WHERE token = ?", (invite_token,))
+        else:
+            cur.execute("UPDATE invites SET used_count = used_count + 1 WHERE token = ?", (invite_token,))
+        conn.commit()
+        conn.close()
+    except Exception as e:
+        logger.exception("Failed to increment invite usage: %s", e)
+
+def log_upload_event(request: Request, invite_token: Optional[str], fingerprint: Optional[str], filename: str, size: int, checksum: str, asset_id: Optional[str]) -> None:
+    """Record uploader identity and file metadata (best-effort)."""
+    try:
+        ip = None
+        try:
+            ip = (request.client.host if request and request.client else None) or request.headers.get('x-forwarded-for')
+        except Exception:
+            ip = None
+        ua = request.headers.get('user-agent', '') if request else ''
+        conn = db.connect()
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO upload_events (token, ip, user_agent, fingerprint, filename, size, checksum, immich_asset_id) VALUES (?,?,?,?,?,?,?,?)",
+            (invite_token or '', ip, ua, fingerprint or '', filename, size, checksum, asset_id or None)
+        )
+        conn.commit()
+        conn.close()
+    except Exception:
+        pass
+
+async def process_upload(
     request: Request,
-    file: UploadFile,
-    item_id: str = Form(...),
-    session_id: str = Form(...),
-    last_modified: Optional[int] = Form(None),
-    invite_token: Optional[str] = Form(None),
-    fingerprint: Optional[str] = Form(None),
-):
-    """Receive a file, check duplicates, forward to Immich; stream progress via WS."""
-    raw = await file.read()
+    *,
+    raw: bytes,
+    orig_name: str,
+    content_type: Optional[str],
+    item_id: str,
+    session_id: str,
+    last_modified: Optional[int],
+    invite_token: Optional[str],
+    fingerprint: Optional[str],
+) -> JSONResponse:
+    """Dedupe-check and forward one file to Immich, streaming progress via WS."""
     size = len(raw)
     checksum = sha1_hex(raw)
 
     exif_created, exif_modified = read_exif_datetimes(raw)
-    created_at = exif_created or (datetime.fromtimestamp(last_modified / 1000) if last_modified else datetime.utcnow())
+    created_at = exif_created or (datetime.fromtimestamp(last_modified / 1000, tz=timezone.utc) if last_modified else datetime.now(timezone.utc))
     modified_at = exif_modified or created_at
-    created_iso = created_at.isoformat()
-    modified_iso = modified_at.isoformat()
+    created_iso = to_immich_iso(created_at)
 
-    device_asset_id = f"{file.filename}-{last_modified or 0}-{size}"
+    # Local dedupe key only; Immich v3 no longer accepts deviceAssetId/deviceId
+    device_asset_id = f"{orig_name}-{last_modified or 0}-{size}"
 
     if db_lookup_checksum(checksum):
         await send_progress(session_id, item_id, "duplicate", 100, "Duplicate (by checksum - local cache)")
@@ -551,220 +606,93 @@ async def api_upload(
     bulk = await immich_bulk_check([{"id": item_id, "checksum": checksum}])
     if bulk.get(item_id, {}).get("action") == "reject" and bulk[item_id].get("reason") == "duplicate":
         asset_id = bulk[item_id].get("assetId")
-        db_insert_upload(checksum, file.filename, size, device_asset_id, asset_id, created_iso)
+        db_insert_upload(checksum, orig_name, size, device_asset_id, asset_id, created_iso)
         await send_progress(session_id, item_id, "duplicate", 100, "Duplicate (server)", asset_id)
         return JSONResponse({"status": "duplicate", "id": asset_id}, status_code=200)
-
-    safe_name = sanitize_filename(file.filename)
-    def gen_encoder() -> MultipartEncoder:
-        return MultipartEncoder(fields={
-            "assetData": (safe_name, io.BytesIO(raw), file.content_type or "application/octet-stream"),
-            "deviceAssetId": device_asset_id,
-            "deviceId": f"python-{session_id}",
-            "fileCreatedAt": created_iso,
-            "fileModifiedAt": modified_iso,
-            "isFavorite": "false",
-            "filename": safe_name,
-            "originalFileName": safe_name,
-        })
-
-    encoder = gen_encoder()
 
     # Invite token validation (if provided)
     target_album_id: Optional[str] = None
     target_album_name: Optional[str] = None
     if invite_token:
-        try:
-            conn = sqlite3.connect(SETTINGS.state_db)
-            cur = conn.cursor()
-            cur.execute("SELECT token, album_id, album_name, max_uses, used_count, expires_at, COALESCE(claimed,0), claimed_by_session, password_hash, COALESCE(disabled,0) FROM invites WHERE token = ?", (invite_token,))
-            row = cur.fetchone()
-            conn.close()
-        except Exception as e:
-            logger.exception("Invite lookup error: %s", e)
-            row = None
-        if not row:
-            await send_progress(session_id, item_id, "error", 100, "Invalid invite token")
-            return JSONResponse({"error": "invalid_invite"}, status_code=403)
-        _, album_id, album_name, max_uses, used_count, expires_at, claimed, claimed_by_session, password_hash, disabled = row
-        # Admin deactivation check
-        try:
-            if int(disabled) == 1:
-                await send_progress(session_id, item_id, "error", 100, "Invite disabled")
-                return JSONResponse({"error": "invite_disabled"}, status_code=403)
-        except Exception:
-            pass
-        # If invite requires password, ensure this session is authorized
-        if password_hash:
-            try:
-                ia = request.session.get("inviteAuth") or {}
-                if not ia.get(invite_token):
-                    await send_progress(session_id, item_id, "error", 100, "Password required")
-                    return JSONResponse({"error": "invite_password_required"}, status_code=403)
-            except Exception:
-                await send_progress(session_id, item_id, "error", 100, "Password required")
-                return JSONResponse({"error": "invite_password_required"}, status_code=403)
-        # Expiry check
-        if expires_at:
-            try:
-                if datetime.utcnow() > datetime.fromisoformat(expires_at):
-                    await send_progress(session_id, item_id, "error", 100, "Invite expired")
-                    return JSONResponse({"error": "invite_expired"}, status_code=403)
-            except Exception:
-                pass
-        # One-time claim or multi-use enforcement
-        try:
-            max_uses_int = int(max_uses) if max_uses is not None else -1
-        except Exception:
-            max_uses_int = -1
-        if max_uses_int == 1:
-            # Already claimed?
-            if claimed:
-                # Allow same session to continue; block different sessions
-                if claimed_by_session and claimed_by_session != session_id:
-                    await send_progress(session_id, item_id, "error", 100, "Invite already used")
-                    return JSONResponse({"error": "invite_claimed"}, status_code=403)
-                # claimed by same session (or unknown): allow
-            else:
-                # Atomically claim the one-time invite to prevent concurrent use
-                try:
-                    connc = sqlite3.connect(SETTINGS.state_db)
-                    curc = connc.cursor()
-                    curc.execute(
-                        "UPDATE invites SET claimed = 1, claimed_at = CURRENT_TIMESTAMP, claimed_by_session = ? WHERE token = ? AND (claimed IS NULL OR claimed = 0)",
-                        (session_id, invite_token)
-                    )
-                    connc.commit()
-                    changed = connc.total_changes
-                    connc.close()
-                except Exception as e:
-                    logger.exception("Invite claim failed: %s", e)
-                    return JSONResponse({"error": "invite_claim_failed"}, status_code=500)
-                if changed == 0:
-                    # Someone else just claimed; re-check owner
-                    try:
-                        conn2 = sqlite3.connect(SETTINGS.state_db)
-                        cur2 = conn2.cursor()
-                        cur2.execute("SELECT claimed_by_session FROM invites WHERE token = ?", (invite_token,))
-                        owner_row = cur2.fetchone()
-                        conn2.close()
-                        owner = owner_row[0] if owner_row else None
-                    except Exception:
-                        owner = None
-                    if not owner or owner != session_id:
-                        await send_progress(session_id, item_id, "error", 100, "Invite already used")
-                        return JSONResponse({"error": "invite_claimed"}, status_code=403)
-        else:
-            # Usage check for multi-use (max_uses < 0 => indefinite)
-            if (used_count or 0) >= (max_uses_int if max_uses_int >= 0 else 10**9):
-                await send_progress(session_id, item_id, "error", 100, "Invite already used up")
-                return JSONResponse({"error": "invite_exhausted"}, status_code=403)
-        target_album_id = album_id
-        target_album_name = album_name
+        error, target_album_id, target_album_name = check_invite_for_upload(request, invite_token, session_id)
+        if error:
+            msg, key, http_status = error
+            await send_progress(session_id, item_id, "error", 100, msg)
+            return JSONResponse({"error": key}, status_code=http_status)
 
-    async def do_upload():
-        await send_progress(session_id, item_id, "uploading", 0, "Uploading…")
-        sent = {"pct": 0}
-        def cb(monitor: MultipartEncoderMonitor) -> None:
-            if monitor.len:
-                pct = int(monitor.bytes_read * 100 / monitor.len)
-                if pct != sent["pct"]:
-                    sent["pct"] = pct
-                    asyncio.create_task(send_progress(session_id, item_id, "uploading", pct))
-        monitor = MultipartEncoderMonitor(encoder, cb)
-        headers = {"Accept": "application/json", "Content-Type": monitor.content_type, "x-immich-checksum": checksum, **immich_headers(request)}
-        try:
-            r = requests.post(f"{SETTINGS.normalized_base_url}/assets", headers=headers, data=monitor, timeout=120)
-            if r.status_code in (200, 201):
-                data = r.json()
-                asset_id = data.get("id")
-                db_insert_upload(checksum, file.filename, size, device_asset_id, asset_id, created_iso)
-                status = data.get("status", "created")
-                
-                # Add to album if configured (invite overrides .env)
-                if asset_id:
-                    added = False
-                    if invite_token:
-                        # Only add if invite specified an album; do not fallback to env default
-                        if target_album_id or target_album_name:
-                            added = await add_asset_to_album(asset_id, request=request, album_id_override=target_album_id, album_name_override=target_album_name)
-                            if added:
-                                status += f" (added to album '{target_album_name or target_album_id}')"
-                    elif SETTINGS.album_name:
-                        if await add_asset_to_album(asset_id, request=request):
-                            status += f" (added to album '{SETTINGS.album_name}')"
+    safe_name = sanitize_filename(orig_name)
+    await send_progress(session_id, item_id, "uploading", 0, "Uploading…")
 
-                await send_progress(session_id, item_id, "duplicate" if status == "duplicate" else "done", 100, status, asset_id)
+    def on_progress(pct: int) -> None:
+        asyncio.create_task(send_progress(session_id, item_id, "uploading", pct))
 
-                # Increment invite usage on success
-                if invite_token:
-                    try:
-                        conn2 = sqlite3.connect(SETTINGS.state_db)
-                        cur2 = conn2.cursor()
-                        # Keep one-time used_count at 1; multi-use increments per asset
-                        cur2.execute("SELECT max_uses FROM invites WHERE token = ?", (invite_token,))
-                        row_mu = cur2.fetchone()
-                        mx = None
-                        try:
-                            mx = int(row_mu[0]) if row_mu and row_mu[0] is not None else None
-                        except Exception:
-                            mx = None
-                        if mx == 1:
-                            cur2.execute("UPDATE invites SET used_count = 1 WHERE token = ?", (invite_token,))
-                        else:
-                            cur2.execute("UPDATE invites SET used_count = used_count + 1 WHERE token = ?", (invite_token,))
-                        conn2.commit()
-                        conn2.close()
-                    except Exception as e:
-                        logger.exception("Failed to increment invite usage: %s", e)
-                # Log uploader identity and file metadata
-                try:
-                    connlg = sqlite3.connect(SETTINGS.state_db)
-                    curlg = connlg.cursor()
-                    curlg.execute(
-                        """
-                        CREATE TABLE IF NOT EXISTS upload_events (
-                            id INTEGER PRIMARY KEY AUTOINCREMENT,
-                            token TEXT,
-                            uploaded_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                            ip TEXT,
-                            user_agent TEXT,
-                            fingerprint TEXT,
-                            filename TEXT,
-                            size INTEGER,
-                            checksum TEXT,
-                            immich_asset_id TEXT
-                        );
-                        """
-                    )
-                    ip = None
-                    try:
-                        ip = (request.client.host if request and request.client else None) or request.headers.get('x-forwarded-for')
-                    except Exception:
-                        ip = None
-                    ua = request.headers.get('user-agent', '') if request else ''
-                    curlg.execute(
-                        "INSERT INTO upload_events (token, ip, user_agent, fingerprint, filename, size, checksum, immich_asset_id) VALUES (?,?,?,?,?,?,?,?)",
-                        (invite_token or '', ip, ua, fingerprint or '', file.filename, size, checksum, asset_id or None)
-                    )
-                    connlg.commit()
-                    connlg.close()
-                except Exception:
-                    pass
-                return JSONResponse({"id": asset_id, "status": status}, status_code=200)
-            else:
-                try:
-                    msg = r.json().get("message", r.text)
-                except Exception:
-                    msg = r.text
-                await send_progress(session_id, item_id, "error", 100, msg)
-                return JSONResponse({"error": msg}, status_code=400)
-        except Exception:
-            logger.exception("upload failed (session=%s item=%s)", session_id, item_id)
+    outcome = await immich_client.upload_asset(
+        app.state.httpx_client,
+        SETTINGS.normalized_base_url,
+        immich_headers(request),
+        file_bytes=raw,
+        filename=safe_name,
+        content_type=content_type or "application/octet-stream",
+        checksum=checksum,
+        created_at=created_at,
+        modified_at=modified_at,
+        progress=on_progress,
+        timeout=300.0,
+    )
+    if not outcome.ok:
+        if outcome.status_code == 0:
+            logger.error("upload failed (session=%s item=%s): %s", session_id, item_id, outcome.error)
             await send_progress(session_id, item_id, "error", 100, "upload failed")
             return JSONResponse({"error": "upload failed"}, status_code=500)
+        msg = outcome.error or "upload failed"
+        await send_progress(session_id, item_id, "error", 100, msg)
+        return JSONResponse({"error": msg}, status_code=400)
 
-    return await do_upload()
+    asset_id = outcome.asset_id
+    status = outcome.status or "created"
+    db_insert_upload(checksum, orig_name, size, device_asset_id, asset_id, created_iso)
+
+    # Add to album if configured (invite overrides .env)
+    if asset_id:
+        if invite_token:
+            # Only add if invite specified an album; do not fallback to env default
+            if target_album_id or target_album_name:
+                if await add_asset_to_album(asset_id, request=request, album_id_override=target_album_id, album_name_override=target_album_name):
+                    status += f" (added to album '{target_album_name or target_album_id}')"
+        elif SETTINGS.album_name:
+            if await add_asset_to_album(asset_id, request=request):
+                status += f" (added to album '{SETTINGS.album_name}')"
+
+    await send_progress(session_id, item_id, "duplicate" if outcome.status == "duplicate" else "done", 100, status, asset_id)
+
+    if invite_token:
+        increment_invite_usage(invite_token)
+    log_upload_event(request, invite_token, fingerprint, orig_name, size, checksum, asset_id)
+    return JSONResponse({"id": asset_id, "status": status}, status_code=200)
+
+@app.post("/api/upload")
+async def api_upload(
+    request: Request,
+    file: UploadFile,
+    item_id: str = Form(...),
+    session_id: str = Form(...),
+    last_modified: Optional[int] = Form(None),
+    invite_token: Optional[str] = Form(None),
+    fingerprint: Optional[str] = Form(None),
+):
+    """Receive a file, check duplicates, forward to Immich; stream progress via WS."""
+    raw = await file.read()
+    return await process_upload(
+        request,
+        raw=raw,
+        orig_name=file.filename or "file",
+        content_type=file.content_type,
+        item_id=item_id,
+        session_id=session_id,
+        last_modified=last_modified,
+        invite_token=invite_token,
+        fingerprint=fingerprint,
+    )
 
 # --------- Chunked upload endpoints ---------
 
@@ -858,7 +786,7 @@ async def api_upload_chunk_complete(request: Request) -> JSONResponse:
         return JSONResponse({"error": "invalid_json"}, status_code=400)
     item_id = (data or {}).get("item_id")
     session_id = (data or {}).get("session_id")
-    name = (data or {}).get("name") or "upload.bin"
+    name = (data or {}).get("name")
     last_modified = (data or {}).get("last_modified")
     invite_token = (data or {}).get("invite_token")
     fingerprint = (data or {}).get("fingerprint")
@@ -867,7 +795,6 @@ async def api_upload_chunk_complete(request: Request) -> JSONResponse:
         return JSONResponse({"error": "missing_ids"}, status_code=400)
     d = _chunk_dir(session_id, item_id)
     meta_path = os.path.join(d, "meta.json")
-    # Basic validation
     try:
         with open(meta_path, "r", encoding="utf-8") as f:
             meta = json.load(f)
@@ -877,265 +804,49 @@ async def api_upload_chunk_complete(request: Request) -> JSONResponse:
     if total_chunks <= 0:
         return JSONResponse({"error": "missing_total"}, status_code=400)
     # Prefer the name captured at init if request did not include it
-    if not name:
-        try:
-            name = meta.get("name") or name
-        except Exception:
-            pass
-    if not name:
-        name = "upload.bin"
-    # Assemble
-    parts = []
+    name = name or meta.get("name") or "upload.bin"
+
+    # Verify all parts exist before consuming any (missing part => client can retry)
+    for i in range(total_chunks):
+        if not os.path.exists(os.path.join(d, f"part_{i:06d}")):
+            return JSONResponse({"error": "missing_part", "index": i}, status_code=400)
+
+    # Assemble by streaming parts into one file (avoids holding two copies in RAM)
+    assembled_path = os.path.join(d, "assembled.bin")
     try:
-        for i in range(total_chunks):
-            p = os.path.join(d, f"part_{i:06d}")
-            if not os.path.exists(p):
-                return JSONResponse({"error": "missing_part", "index": i}, status_code=400)
-            with open(p, "rb") as f:
-                parts.append(f.read())
-        raw = b"".join(parts)
+        with open(assembled_path, "wb") as out:
+            for i in range(total_chunks):
+                p = os.path.join(d, f"part_{i:06d}")
+                with open(p, "rb") as f:
+                    while True:
+                        buf = f.read(1024 * 1024)
+                        if not buf:
+                            break
+                        out.write(buf)
+                os.remove(p)
+        with open(assembled_path, "rb") as f:
+            raw = f.read()
     except Exception as e:
         logger.exception("Assemble failed: %s", e)
         return JSONResponse({"error": "assemble_failed"}, status_code=500)
-    # Cleanup parts promptly
-    try:
-        for i in range(total_chunks):
-            try:
-                os.remove(os.path.join(d, f"part_{i:06d}"))
-            except Exception:
-                pass
-        try:
-            os.remove(meta_path)
-        except Exception:
-            pass
-        try:
+    finally:
+        for leftover in (assembled_path, meta_path):
+            with suppress(Exception):
+                os.remove(leftover)
+        with suppress(Exception):
             os.rmdir(d)
-        except Exception:
-            pass
-    except Exception:
-        pass
 
-    # Now reuse the core logic from api_upload but with assembled bytes
-    item_id_local = item_id
-    session_id_local = session_id
-    file_like_name = name
-    file_size = len(raw)
-    checksum = sha1_hex(raw)
-    exif_created, exif_modified = read_exif_datetimes(raw)
-    created_at = exif_created or (datetime.fromtimestamp(last_modified / 1000) if last_modified else datetime.utcnow())
-    modified_at = exif_modified or created_at
-    created_iso = created_at.isoformat()
-    modified_iso = modified_at.isoformat()
-    device_asset_id = f"{file_like_name}-{last_modified or 0}-{file_size}"
-
-    # Local duplicate checks
-    if db_lookup_checksum(checksum):
-        await send_progress(session_id_local, item_id_local, "duplicate", 100, "Duplicate (by checksum - local cache)")
-        return JSONResponse({"status": "duplicate", "id": None}, status_code=200)
-    if db_lookup_device_asset(device_asset_id):
-        await send_progress(session_id_local, item_id_local, "duplicate", 100, "Already uploaded from this device (local cache)")
-        return JSONResponse({"status": "duplicate", "id": None}, status_code=200)
-
-    await send_progress(session_id_local, item_id_local, "checking", 2, "Checking duplicates…")
-    bulk = await immich_bulk_check([{ "id": item_id_local, "checksum": checksum }])
-    if bulk.get(item_id_local, {}).get("action") == "reject" and bulk[item_id_local].get("reason") == "duplicate":
-        asset_id = bulk[item_id_local].get("assetId")
-        db_insert_upload(checksum, file_like_name, file_size, device_asset_id, asset_id, created_iso)
-        await send_progress(session_id_local, item_id_local, "duplicate", 100, "Duplicate (server)", asset_id)
-        return JSONResponse({"status": "duplicate", "id": asset_id}, status_code=200)
-
-    safe_name2 = sanitize_filename(file_like_name)
-    def gen_encoder2() -> MultipartEncoder:
-        return MultipartEncoder(fields={
-            "assetData": (safe_name2, io.BytesIO(raw), content_type or "application/octet-stream"),
-            "deviceAssetId": device_asset_id,
-            "deviceId": f"python-{session_id_local}",
-            "fileCreatedAt": created_iso,
-            "fileModifiedAt": modified_iso,
-            "isFavorite": "false",
-            "filename": safe_name2,
-            "originalFileName": safe_name2,
-        })
-
-    # Invite validation/gating mirrors api_upload
-    target_album_id: Optional[str] = None
-    target_album_name: Optional[str] = None
-    if invite_token:
-        try:
-            conn = sqlite3.connect(SETTINGS.state_db)
-            cur = conn.cursor()
-            cur.execute("SELECT token, album_id, album_name, max_uses, used_count, expires_at, COALESCE(claimed,0), claimed_by_session, password_hash, COALESCE(disabled,0) FROM invites WHERE token = ?", (invite_token,))
-            row = cur.fetchone()
-            conn.close()
-        except Exception as e:
-            logger.exception("Invite lookup error: %s", e)
-            row = None
-        if not row:
-            await send_progress(session_id_local, item_id_local, "error", 100, "Invalid invite token")
-            return JSONResponse({"error": "invalid_invite"}, status_code=403)
-        _, album_id, album_name, max_uses, used_count, expires_at, claimed, claimed_by_session, password_hash, disabled = row
-        # Admin deactivation check
-        try:
-            if int(disabled) == 1:
-                await send_progress(session_id_local, item_id_local, "error", 100, "Invite disabled")
-                return JSONResponse({"error": "invite_disabled"}, status_code=403)
-        except Exception:
-            pass
-        if password_hash:
-            try:
-                ia = request.session.get("inviteAuth") or {}
-                if not ia.get(invite_token):
-                    await send_progress(session_id_local, item_id_local, "error", 100, "Password required")
-                    return JSONResponse({"error": "invite_password_required"}, status_code=403)
-            except Exception:
-                await send_progress(session_id_local, item_id_local, "error", 100, "Password required")
-                return JSONResponse({"error": "invite_password_required"}, status_code=403)
-        # expiry
-        if expires_at:
-            try:
-                if datetime.utcnow() > datetime.fromisoformat(expires_at):
-                    await send_progress(session_id_local, item_id_local, "error", 100, "Invite expired")
-                    return JSONResponse({"error": "invite_expired"}, status_code=403)
-            except Exception:
-                pass
-        try:
-            max_uses_int = int(max_uses) if max_uses is not None else -1
-        except Exception:
-            max_uses_int = -1
-        if max_uses_int == 1:
-            if claimed:
-                if claimed_by_session and claimed_by_session != session_id_local:
-                    await send_progress(session_id_local, item_id_local, "error", 100, "Invite already used")
-                    return JSONResponse({"error": "invite_claimed"}, status_code=403)
-            else:
-                try:
-                    connc = sqlite3.connect(SETTINGS.state_db)
-                    curc = connc.cursor()
-                    curc.execute(
-                        "UPDATE invites SET claimed = 1, claimed_at = CURRENT_TIMESTAMP, claimed_by_session = ? WHERE token = ? AND (claimed IS NULL OR claimed = 0)",
-                        (session_id_local, invite_token)
-                    )
-                    connc.commit()
-                    changed = connc.total_changes
-                    connc.close()
-                except Exception as e:
-                    logger.exception("Invite claim failed: %s", e)
-                    return JSONResponse({"error": "invite_claim_failed"}, status_code=500)
-                if changed == 0:
-                    try:
-                        conn2 = sqlite3.connect(SETTINGS.state_db)
-                        cur2 = conn2.cursor()
-                        cur2.execute("SELECT claimed_by_session FROM invites WHERE token = ?", (invite_token,))
-                        owner_row = cur2.fetchone()
-                        conn2.close()
-                        owner = owner_row[0] if owner_row else None
-                    except Exception:
-                        owner = None
-                    if not owner or owner != session_id_local:
-                        await send_progress(session_id_local, item_id_local, "error", 100, "Invite already used")
-                        return JSONResponse({"error": "invite_claimed"}, status_code=403)
-        else:
-            if (used_count or 0) >= (max_uses_int if max_uses_int >= 0 else 10**9):
-                await send_progress(session_id_local, item_id_local, "error", 100, "Invite already used up")
-                return JSONResponse({"error": "invite_exhausted"}, status_code=403)
-        target_album_id = album_id
-        target_album_name = album_name
-
-    await send_progress(session_id_local, item_id_local, "uploading", 0, "Uploading…")
-    sent = {"pct": 0}
-    def cb2(monitor: MultipartEncoderMonitor) -> None:
-        if monitor.len:
-            pct = int(monitor.bytes_read * 100 / monitor.len)
-            if pct != sent["pct"]:
-                sent["pct"] = pct
-                asyncio.create_task(send_progress(session_id_local, item_id_local, "uploading", pct))
-    encoder2 = gen_encoder2()
-    monitor2 = MultipartEncoderMonitor(encoder2, cb2)
-    headers = {"Accept": "application/json", "Content-Type": monitor2.content_type, "x-immich-checksum": checksum, **immich_headers(request)}
-    try:
-        r = requests.post(f"{SETTINGS.normalized_base_url}/assets", headers=headers, data=monitor2, timeout=120)
-        if r.status_code in (200, 201):
-            data_r = r.json()
-            asset_id = data_r.get("id")
-            db_insert_upload(checksum, file_like_name, file_size, device_asset_id, asset_id, created_iso)
-            status = data_r.get("status", "created")
-            if asset_id:
-                added = False
-                if invite_token:
-                    # Only add if invite specified an album; do not fallback to env default
-                    if target_album_id or target_album_name:
-                        added = await add_asset_to_album(asset_id, request=request, album_id_override=target_album_id, album_name_override=target_album_name)
-                        if added:
-                            status += f" (added to album '{target_album_name or target_album_id}')"
-                elif SETTINGS.album_name:
-                    if await add_asset_to_album(asset_id, request=request):
-                        status += f" (added to album '{SETTINGS.album_name}')"
-            await send_progress(session_id_local, item_id_local, "duplicate" if status == "duplicate" else "done", 100, status, asset_id)
-            if invite_token:
-                try:
-                    conn2 = sqlite3.connect(SETTINGS.state_db)
-                    cur2 = conn2.cursor()
-                    cur2.execute("SELECT max_uses FROM invites WHERE token = ?", (invite_token,))
-                    row_mu = cur2.fetchone()
-                    mx = None
-                    try:
-                        mx = int(row_mu[0]) if row_mu and row_mu[0] is not None else None
-                    except Exception:
-                        mx = None
-                    if mx == 1:
-                        cur2.execute("UPDATE invites SET used_count = 1 WHERE token = ?", (invite_token,))
-                    else:
-                        cur2.execute("UPDATE invites SET used_count = used_count + 1 WHERE token = ?", (invite_token,))
-                    conn2.commit()
-                    conn2.close()
-                except Exception as e:
-                    logger.exception("Failed to increment invite usage: %s", e)
-            # Log uploader identity and file metadata
-            try:
-                connlg = sqlite3.connect(SETTINGS.state_db)
-                curlg = connlg.cursor()
-                curlg.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS upload_events (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT,
-                        token TEXT,
-                        uploaded_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                        ip TEXT,
-                        user_agent TEXT,
-                        fingerprint TEXT,
-                        filename TEXT,
-                        size INTEGER,
-                        checksum TEXT,
-                        immich_asset_id TEXT
-                    );
-                    """
-                )
-                ip = None
-                try:
-                    ip = (request.client.host if request and request.client else None) or request.headers.get('x-forwarded-for')
-                except Exception:
-                    ip = None
-                ua = request.headers.get('user-agent', '') if request else ''
-                curlg.execute(
-                    "INSERT INTO upload_events (token, ip, user_agent, fingerprint, filename, size, checksum, immich_asset_id) VALUES (?,?,?,?,?,?,?,?)",
-                    (invite_token or '', ip, ua, fingerprint or '', file_like_name, file_size, checksum, asset_id or None)
-                )
-                connlg.commit()
-                connlg.close()
-            except Exception:
-                pass
-            return JSONResponse({"id": asset_id, "status": status}, status_code=200)
-        else:
-            try:
-                msg = r.json().get("message", r.text)
-            except Exception:
-                msg = r.text
-            await send_progress(session_id_local, item_id_local, "error", 100, msg)
-            return JSONResponse({"error": msg}, status_code=400)
-    except Exception:
-        logger.exception("chunk upload failed (session=%s item=%s)", session_id_local, item_id_local)
-        await send_progress(session_id_local, item_id_local, "error", 100, "upload failed")
-        return JSONResponse({"error": "upload failed"}, status_code=500)
+    return await process_upload(
+        request,
+        raw=raw,
+        orig_name=name,
+        content_type=content_type,
+        item_id=item_id,
+        session_id=session_id,
+        last_modified=last_modified,
+        invite_token=invite_token,
+        fingerprint=fingerprint,
+    )
 
 @app.post("/api/album/reset")
 async def api_album_reset() -> dict:
@@ -1233,94 +944,31 @@ async def api_albums_create(request: Request) -> JSONResponse:
     return JSONResponse({"error": "unexpected_status", "status": r.status_code, "body": r.text}, status_code=502)
 
 # ---------- Invites (one-time/expiring links) ----------
+# Tables are created at startup by db.init_db().
 
-def ensure_invites_table() -> None:
+def hash_password(pw: str) -> str:
+    """PBKDF2-SHA256 hash for invite passwords."""
+    if not pw:
+        return ""
+    salt = os.urandom(16)
+    iterations = 200_000
+    dk = hashlib.pbkdf2_hmac('sha256', pw.encode('utf-8'), salt, iterations)
+    return f"pbkdf2_sha256${iterations}${binascii.hexlify(salt).decode()}${binascii.hexlify(dk).decode()}"
+
+def verify_password(stored: str, pw: Optional[str]) -> bool:
+    """Verify a password against a stored pbkdf2_sha256 hash."""
+    if not pw:
+        return False
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
-        cur = conn.cursor()
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS invites (
-                token TEXT PRIMARY KEY,
-                album_id TEXT,
-                album_name TEXT,
-                max_uses INTEGER DEFAULT 1,
-                used_count INTEGER DEFAULT 0,
-                expires_at TEXT,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
-            );
-            """
-        )
-        # Attempt to add new columns for claiming semantics
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN claimed INTEGER DEFAULT 0")
-        except Exception:
-            pass
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN claimed_at TEXT")
-        except Exception:
-            pass
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN claimed_by_session TEXT")
-        except Exception:
-            pass
-        # Optional password protection for invites
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN password_hash TEXT")
-        except Exception:
-            pass
-        # Ownership and management fields (best-effort migrations)
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN owner_user_id TEXT")
-        except Exception:
-            pass
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN owner_email TEXT")
-        except Exception:
-            pass
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN owner_name TEXT")
-        except Exception:
-            pass
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN name TEXT")
-        except Exception:
-            pass
-        try:
-            cur.execute("ALTER TABLE invites ADD COLUMN disabled INTEGER DEFAULT 0")
-        except Exception:
-            pass
-        conn.commit()
-        conn.close()
-    except Exception as e:
-        logger.exception("Failed to ensure invites table: %s", e)
-
-ensure_invites_table()
-
-# ---------- Platform Cookies (for yt-dlp authenticated downloads) ----------
-
-def ensure_platform_cookies_table() -> None:
-    """Create the platform_cookies table for storing yt-dlp authentication cookies."""
-    try:
-        conn = sqlite3.connect(SETTINGS.state_db)
-        cur = conn.cursor()
-        cur.execute(
-            """
-            CREATE TABLE IF NOT EXISTS platform_cookies (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                platform TEXT NOT NULL UNIQUE,
-                cookie_string TEXT NOT NULL,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
-            );
-            """
-        )
-        conn.commit()
-        conn.close()
-    except Exception as e:
-        logger.exception("Failed to ensure platform_cookies table: %s", e)
-
-ensure_platform_cookies_table()
+        algo, iter_s, salt_hex, hash_hex = stored.split("$")
+        if algo != 'pbkdf2_sha256':
+            return False
+        iterations = int(iter_s)
+        salt = binascii.unhexlify(salt_hex)
+        dk = hashlib.pbkdf2_hmac('sha256', pw.encode('utf-8'), salt, iterations)
+        return binascii.hexlify(dk).decode() == hash_hex
+    except Exception:
+        return False
 
 @app.post("/api/invites")
 async def api_invites_create(request: Request) -> JSONResponse:
@@ -1348,7 +996,7 @@ async def api_invites_create(request: Request) -> JSONResponse:
     # If only album_name provided, resolve or create now to fix to an ID
     resolved_album_id = None
     if not album_id and album_name:
-        resolved_album_id = get_or_create_album(request=request, album_name_override=album_name)
+        resolved_album_id = await get_or_create_album(request=request, album_name_override=album_name)
     else:
         resolved_album_id = album_id
     # Compute expiry
@@ -1356,28 +1004,12 @@ async def api_invites_create(request: Request) -> JSONResponse:
     if expires_days is not None:
         try:
             days = int(expires_days)
-            expires_at = (datetime.utcnow()).replace(microsecond=0).isoformat()
-            # Use timedelta
-            from datetime import timedelta
             expires_at = (datetime.utcnow() + timedelta(days=days)).replace(microsecond=0).isoformat()
         except Exception:
             expires_at = None
     # Generate token
     import uuid
     token = uuid.uuid4().hex
-    # Prepare password hash, if provided
-    def hash_password(pw: str) -> str:
-        try:
-            if not pw:
-                return ""
-            import os as _os
-            import binascii as _binascii
-            salt = _os.urandom(16)
-            iterations = 200_000
-            dk = hashlib.pbkdf2_hmac('sha256', pw.encode('utf-8'), salt, iterations)
-            return f"pbkdf2_sha256${iterations}${_binascii.hexlify(salt).decode()}${_binascii.hexlify(dk).decode()}"
-        except Exception:
-            return ""
     pw_hash = hash_password(invite_password or "") if (invite_password and str(invite_password).strip()) else None
     # Owner info from session
     owner_user_id = str(request.session.get("userId") or "")
@@ -1388,7 +1020,7 @@ async def api_invites_create(request: Request) -> JSONResponse:
     now_tag = datetime.utcnow().strftime("%Y%m%d-%H%M")
     default_link_name = f"{album_name or 'NoAlbum'}-{now_tag}"
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         if pw_hash:
             cur.execute(
@@ -1446,7 +1078,7 @@ async def api_invites_list(request: Request) -> JSONResponse:
     elif sort in ("-name",):
         sort_sql = "name DESC"
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         if q:
             like = f"%{q}%"
@@ -1563,7 +1195,6 @@ async def api_invite_update(token: str, request: Request) -> JSONResponse:
         else:
             try:
                 days = int((body or {}).get("expiresDays"))
-                from datetime import timedelta
                 expires_at = (datetime.utcnow() + timedelta(days=days)).replace(microsecond=0).isoformat()
             except Exception:
                 expires_at = None
@@ -1573,23 +1204,15 @@ async def api_invite_update(token: str, request: Request) -> JSONResponse:
     if "password" in (body or {}):
         pw = str((body or {}).get("password") or "").strip()
         if pw:
-            # Reuse hasher from above
-            def _hash_pw(pw: str) -> str:
-                import os as _os
-                import binascii as _binascii
-                salt = _os.urandom(16)
-                iterations = 200_000
-                dk = hashlib.pbkdf2_hmac('sha256', pw.encode('utf-8'), salt, iterations)
-                return f"pbkdf2_sha256${iterations}${_binascii.hexlify(salt).decode()}${_binascii.hexlify(dk).decode()}"
             fields.append("password_hash = ?")
-            params.append(_hash_pw(pw))
+            params.append(hash_password(pw))
         else:
             fields.append("password_hash = NULL")
     # Reset usage
     reset_usage = bool((body or {}).get("resetUsage"))
     try:
         if fields:
-            conn = sqlite3.connect(SETTINGS.state_db)
+            conn = db.connect()
             cur = conn.cursor()
             cur.execute(
                 f"UPDATE invites SET {', '.join(fields)} WHERE token = ? AND owner_user_id = ?",
@@ -1625,7 +1248,7 @@ async def api_invites_bulk(request: Request) -> JSONResponse:
     val = 1 if action == "disable" else 0
     owner_user_id = str(request.session.get("userId") or "")
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         # Build query with correct number of placeholders
         placeholders = ",".join(["?"] * len(tokens))
@@ -1658,7 +1281,7 @@ async def api_invites_delete(request: Request) -> JSONResponse:
         return JSONResponse({"error": "missing_tokens"}, status_code=400)
     owner_user_id = str(request.session.get("userId") or "")
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         placeholders = ",".join(["?"] * len(tokens))
         # Delete upload events first to avoid orphan rows
@@ -1686,7 +1309,7 @@ async def api_invite_uploads(token: str, request: Request) -> JSONResponse:
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     owner_user_id = str(request.session.get("userId") or "")
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         # Verify ownership
         cur.execute("SELECT 1 FROM invites WHERE token = ? AND owner_user_id = ?", (token, owner_user_id))
@@ -1716,15 +1339,12 @@ async def api_invite_uploads(token: str, request: Request) -> JSONResponse:
 
 @app.get("/invite/{token}", response_class=HTMLResponse)
 async def invite_page(token: str, request: Request) -> HTMLResponse:
-    # If public invites disabled and no user session, require login
-    #if  not request.session.get("accessToken"):
-    #    return RedirectResponse(url="/login")
     return FileResponse(os.path.join(FRONTEND_DIR, "invite.html"))
 
 @app.get("/api/invite/{token}")
 async def api_invite_info(token: str, request: Request) -> JSONResponse:
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         cur.execute("SELECT token, album_id, album_name, max_uses, used_count, expires_at, COALESCE(claimed,0), claimed_at, password_hash, COALESCE(disabled,0), name FROM invites WHERE token = ?", (token,))
         row = cur.fetchone()
@@ -1824,7 +1444,7 @@ async def api_invite_auth(token: str, request: Request) -> JSONResponse:
         body = None
     provided = (body or {}).get("password") if isinstance(body, dict) else None
     try:
-        conn = sqlite3.connect(SETTINGS.state_db)
+        conn = db.connect()
         cur = conn.cursor()
         cur.execute("SELECT password_hash FROM invites WHERE token = ?", (token,))
         row = cur.fetchone()
@@ -1841,21 +1461,6 @@ async def api_invite_auth(token: str, request: Request) -> JSONResponse:
         ia[token] = True
         request.session["inviteAuth"] = ia
         return JSONResponse({"ok": True, "authorized": True})
-    # verify
-    def verify_password(stored: str, pw: Optional[str]) -> bool:
-        if not pw:
-            return False
-        try:
-            algo, iter_s, salt_hex, hash_hex = stored.split("$")
-            if algo != 'pbkdf2_sha256':
-                return False
-            iterations = int(iter_s)
-            import binascii as _binascii
-            salt = _binascii.unhexlify(salt_hex)
-            dk = hashlib.pbkdf2_hmac('sha256', pw.encode('utf-8'), salt, iterations)
-            return _binascii.hexlify(dk).decode() == hash_hex
-        except Exception:
-            return False
     if not verify_password(password_hash, provided):
         return JSONResponse({"error": "invalid_password"}, status_code=403)
     ia = request.session.get("inviteAuth") or {}
@@ -1936,8 +1541,3 @@ async def api_cookies_delete(request: Request, platform: str) -> JSONResponse:
     if deleted:
         return JSONResponse({"ok": True, "deleted": platform})
     return JSONResponse({"error": "not_found"}, status_code=404)
-
-"""
-Note: Do not run this module directly. Use `python main.py` from
-project root, which starts `uvicorn app.app:app` with reload.
-"""

--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,6 @@ class Settings:
     """App settings loaded from environment variables (.env)."""
     immich_base_url: str
     immich_api_key: str
-    max_concurrent: int
     album_name: str = ""
     public_upload_page_enabled: bool = False
     public_base_url: str = ""
@@ -29,7 +28,7 @@ class Settings:
     gallery_dl_timeout: int = 300
     download_concurrency: int = 1
     instagram_ytdlp_fallback: bool = False
-    social_media_uploads: bool = False
+    social_media_uploads: bool = True
 
     @property
     def normalized_base_url(self) -> str:
@@ -38,7 +37,7 @@ class Settings:
 
 def load_settings() -> Settings:
     """Load settings from .env, applying defaults when absent."""
-    # Load environment variables from .env once here so importers don’t have to
+    # Load environment variables from .env once here so importers don't have to
     try:
         load_dotenv()
     except Exception:
@@ -52,10 +51,6 @@ def load_settings() -> Settings:
             return default
         return str(v).strip().lower() in {"1","true","yes","on"}
     public_upload = as_bool(os.getenv("PUBLIC_UPLOAD_PAGE_ENABLED", "false"), False)
-    try:
-        maxc = int(os.getenv("MAX_CONCURRENT", "3"))
-    except ValueError:
-        maxc = 3
     state_db = os.getenv("STATE_DB", "/data/state.db")
     session_secret = os.getenv("SESSION_SECRET") or secrets.token_hex(32)
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -79,7 +74,6 @@ def load_settings() -> Settings:
     return Settings(
         immich_base_url=base,
         immich_api_key=api_key,
-        max_concurrent=maxc,
         album_name=album_name,
         public_upload_page_enabled=public_upload,
         public_base_url=os.getenv("PUBLIC_BASE_URL", ""),

--- a/app/cookie_manager.py
+++ b/app/cookie_manager.py
@@ -276,25 +276,6 @@ def db_list_cookies(state_db: str) -> list[dict]:
         return []
 
 
-def db_get_cookie(state_db: str, platform: str) -> Optional[dict]:
-    """Get a single platform cookie."""
-    try:
-        conn = sqlite3.connect(state_db)
-        conn.row_factory = sqlite3.Row
-        cur = conn.cursor()
-        cur.execute(
-            "SELECT platform, cookie_string, created_at, updated_at "
-            "FROM platform_cookies WHERE platform = ?",
-            (platform.lower(),)
-        )
-        row = cur.fetchone()
-        conn.close()
-        return dict(row) if row else None
-    except Exception as e:
-        logger.warning("Failed to get cookie for %s: %s", platform, e)
-        return None
-
-
 def db_upsert_cookie(state_db: str, platform: str, cookie_string: str) -> bool:
     """Create or update a platform cookie."""
     platform = platform.lower()

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,106 @@
+"""
+Central SQLite access for immich-drop.
+All connections go through connect(); all tables and migrations are created
+once at startup via init_db() instead of ad hoc DDL in request handlers.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+logger = logging.getLogger("immich_drop.db")
+
+_DB_PATH: str = ""
+
+
+def configure(path: str) -> None:
+    global _DB_PATH
+    _DB_PATH = path
+
+
+def connect() -> sqlite3.Connection:
+    """Return a new connection to the state DB (short-lived, caller closes)."""
+    return sqlite3.connect(_DB_PATH, timeout=10)
+
+
+def init_db() -> None:
+    """Create all tables and run best-effort column migrations (idempotent)."""
+    conn = connect()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS uploads (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                checksum TEXT UNIQUE,
+                filename TEXT,
+                size INTEGER,
+                device_asset_id TEXT,
+                immich_asset_id TEXT,
+                created_at TEXT,
+                inserted_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS invites (
+                token TEXT PRIMARY KEY,
+                album_id TEXT,
+                album_name TEXT,
+                max_uses INTEGER DEFAULT 1,
+                used_count INTEGER DEFAULT 0,
+                expires_at TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        # Best-effort column migrations for older databases
+        for ddl in (
+            "ALTER TABLE invites ADD COLUMN claimed INTEGER DEFAULT 0",
+            "ALTER TABLE invites ADD COLUMN claimed_at TEXT",
+            "ALTER TABLE invites ADD COLUMN claimed_by_session TEXT",
+            "ALTER TABLE invites ADD COLUMN password_hash TEXT",
+            "ALTER TABLE invites ADD COLUMN owner_user_id TEXT",
+            "ALTER TABLE invites ADD COLUMN owner_email TEXT",
+            "ALTER TABLE invites ADD COLUMN owner_name TEXT",
+            "ALTER TABLE invites ADD COLUMN name TEXT",
+            "ALTER TABLE invites ADD COLUMN disabled INTEGER DEFAULT 0",
+        ):
+            try:
+                cur.execute(ddl)
+            except sqlite3.OperationalError:
+                pass
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS platform_cookies (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                platform TEXT NOT NULL UNIQUE,
+                cookie_string TEXT NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS upload_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                token TEXT,
+                uploaded_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                ip TEXT,
+                user_agent TEXT,
+                fingerprint TEXT,
+                filename TEXT,
+                size INTEGER,
+                checksum TEXT,
+                immich_asset_id TEXT
+            );
+            """
+        )
+        conn.commit()
+    except Exception as e:
+        logger.exception("Failed to initialize state DB: %s", e)
+    finally:
+        conn.close()

--- a/app/immich_client.py
+++ b/app/immich_client.py
@@ -1,0 +1,238 @@
+"""
+Single client for all Immich server API calls (v3 API).
+
+Immich v3 validates upload fields with Zod: unknown fields are rejected and
+fileCreatedAt/fileModifiedAt must be ISO-8601 with an explicit timezone
+offset. AssetMediaCreateDto allows only: assetData, duration, fileCreatedAt,
+fileModifiedAt, filename, isFavorite, livePhotoVideoId, metadata,
+sidecarData, visibility.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger("immich_drop.immich_client")
+
+_UPLOAD_CHUNK = 1024 * 1024  # 1 MiB
+
+
+def to_immich_iso(dt: Optional[datetime]) -> str:
+    """Format a datetime as ISO-8601 with a timezone offset (required by v3)."""
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat(timespec="milliseconds")
+
+
+def parse_error(resp: httpx.Response) -> str:
+    """Extract a readable message from an Immich error response.
+
+    v3 returns Zod-shaped bodies where message may be a string, list, or
+    nested error objects.
+    """
+    try:
+        data = resp.json()
+    except Exception:
+        return (resp.text or f"HTTP {resp.status_code}").strip()[:300]
+    msg = data.get("message") if isinstance(data, dict) else None
+    if isinstance(msg, list):
+        msg = "; ".join(str(m) for m in msg)
+    elif isinstance(msg, dict):
+        msg = json.dumps(msg)
+    if not msg and isinstance(data, dict):
+        errs = data.get("errors")
+        if isinstance(errs, list):
+            parts = []
+            for e in errs:
+                if isinstance(e, dict):
+                    path = e.get("path")
+                    m = e.get("message") or e.get("code") or json.dumps(e)
+                    parts.append(f"{path}: {m}" if path else str(m))
+                else:
+                    parts.append(str(e))
+            msg = "; ".join(parts)
+    return str(msg or resp.text or f"HTTP {resp.status_code}").strip()[:300]
+
+
+@dataclass
+class UploadOutcome:
+    ok: bool
+    status_code: int
+    asset_id: Optional[str] = None
+    status: str = ""  # "created" or "duplicate" on success
+    error: Optional[str] = None
+
+
+def _multipart_parts(fields: Dict[str, str], filename: str, content_type: str, boundary: str) -> tuple[bytes, bytes]:
+    """Build the multipart head (fields + file part header) and tail."""
+    safe = filename.replace("\\", "_").replace('"', "'")
+    head = "".join(
+        f"--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n"
+        for k, v in fields.items()
+    )
+    head += (
+        f"--{boundary}\r\nContent-Disposition: form-data; name=\"assetData\"; "
+        f"filename=\"{safe}\"\r\nContent-Type: {content_type}\r\n\r\n"
+    )
+    tail = f"\r\n--{boundary}--\r\n"
+    return head.encode("utf-8"), tail.encode("utf-8")
+
+
+async def upload_asset(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: Dict[str, str],
+    *,
+    file_bytes: bytes,
+    filename: str,
+    content_type: str,
+    checksum: str,
+    created_at: Optional[datetime] = None,
+    modified_at: Optional[datetime] = None,
+    progress: Optional[Callable[[int], None]] = None,
+    timeout: float = 300.0,
+) -> UploadOutcome:
+    """POST /assets with a streaming multipart body and optional progress callback.
+
+    progress is called with 0-100 whenever the sent percentage changes.
+    """
+    fields = {
+        "fileCreatedAt": to_immich_iso(created_at),
+        "fileModifiedAt": to_immich_iso(modified_at or created_at),
+        "isFavorite": "false",
+        "filename": filename,
+    }
+    boundary = uuid.uuid4().hex
+    head, tail = _multipart_parts(fields, filename, content_type or "application/octet-stream", boundary)
+    total = len(head) + len(file_bytes) + len(tail)
+
+    async def body():
+        sent = 0
+        last_pct = -1
+        for blob in (head, file_bytes, tail):
+            for i in range(0, len(blob), _UPLOAD_CHUNK):
+                chunk = blob[i:i + _UPLOAD_CHUNK]
+                sent += len(chunk)
+                if progress:
+                    pct = int(sent * 100 / total)
+                    if pct != last_pct:
+                        last_pct = pct
+                        progress(pct)
+                yield chunk
+                # Let progress messages flush between chunks
+                await asyncio.sleep(0)
+
+    req_headers = {
+        **headers,
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "Content-Length": str(total),
+        "x-immich-checksum": checksum,
+    }
+    try:
+        r = await client.post(f"{base_url}/assets", headers=req_headers, content=body(), timeout=timeout)
+    except Exception as e:
+        return UploadOutcome(ok=False, status_code=0, error=str(e))
+    if r.status_code in (200, 201):
+        data = r.json()
+        return UploadOutcome(
+            ok=True,
+            status_code=r.status_code,
+            asset_id=data.get("id"),
+            status=data.get("status", "created"),
+        )
+    return UploadOutcome(ok=False, status_code=r.status_code, error=parse_error(r))
+
+
+async def bulk_upload_check(client: httpx.AsyncClient, base_url: str, headers: Dict[str, str], checks: List[dict]) -> Dict[str, dict]:
+    """POST /assets/bulk-upload-check; returns map id->result (empty on failure)."""
+    try:
+        r = await client.post(
+            f"{base_url}/assets/bulk-upload-check",
+            headers=headers,
+            json={"assets": checks},
+            timeout=10.0,
+        )
+        if r.status_code == 200:
+            results = r.json().get("results", [])
+            return {x["id"]: x for x in results}
+    except Exception:
+        pass
+    return {}
+
+
+async def find_or_create_album(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: Dict[str, str],
+    album_name: str,
+    description: Optional[str] = None,
+) -> Optional[str]:
+    """Find an album by name or create it. Returns the album id or None."""
+    try:
+        r = await client.get(f"{base_url}/albums", headers=headers, timeout=10.0)
+        if r.status_code == 200:
+            for album in r.json():
+                if album.get("albumName") == album_name:
+                    return album.get("id")
+        elif r.status_code >= 500:
+            # Do not create albums while Immich is erroring; avoids duplicates
+            logger.warning("Immich returned %s when listing albums, skipping album assignment", r.status_code)
+            return None
+        payload = {"albumName": album_name}
+        if description:
+            payload["description"] = description
+        r = await client.post(
+            f"{base_url}/albums",
+            headers={**headers, "Content-Type": "application/json"},
+            json=payload,
+            timeout=10.0,
+        )
+        if r.status_code in (200, 201):
+            return r.json().get("id")
+        logger.warning("Failed to create album: %s - %s", r.status_code, parse_error(r))
+    except Exception as e:
+        logger.exception("Error managing album: %s", e)
+    return None
+
+
+async def add_to_album(client: httpx.AsyncClient, base_url: str, headers: Dict[str, str], album_id: str, asset_id: str) -> bool:
+    """PUT /albums/{id}/assets. Duplicate membership counts as success."""
+    if not album_id or not asset_id:
+        return False
+    try:
+        r = await client.put(
+            f"{base_url}/albums/{album_id}/assets",
+            headers={**headers, "Content-Type": "application/json"},
+            json={"ids": [asset_id]},
+            timeout=10.0,
+        )
+        if r.status_code == 200:
+            for result in r.json():
+                if result.get("success") or result.get("error") == "duplicate":
+                    return True
+        return False
+    except Exception as e:
+        logger.exception("Error adding asset to album: %s", e)
+        return False
+
+
+async def ping(client: httpx.AsyncClient, base_url: str, headers: Dict[str, str]) -> bool:
+    """Best-effort reachability check (v3 endpoints)."""
+    for path in ("/server/ping", "/server/version", "/users/me"):
+        try:
+            r = await client.get(f"{base_url}{path}", headers=headers, timeout=4.0)
+            if 200 <= r.status_code < 400:
+                return True
+        except Exception:
+            continue
+    return False

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -232,11 +232,6 @@ def is_direct_image_url(url: str) -> bool:
     return False
 
 
-def is_supported_url(url: str) -> bool:
-    """Check if URL is from a supported platform or a direct image URL"""
-    return identify_platform(url) is not None or is_direct_image_url(url)
-
-
 async def download_direct_image(
     url: str,
     output_dir: Optional[str] = None,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -67,7 +67,10 @@ function updateThemeIcon(){
 }
 
 function initDarkMode(){
-  themeMode = 'system';
+  try{
+    const saved = localStorage.getItem('immich_drop_theme');
+    themeMode = (saved === 'light' || saved === 'dark') ? saved : 'system';
+  }catch{ themeMode = 'system'; }
   applyTheme(themeMode);
   updateThemeIcon();
   if (prefersDark && prefersDark.addEventListener) {
@@ -79,6 +82,7 @@ function initDarkMode(){
 
 function toggleDarkMode() {
   themeMode = (themeMode === 'dark') ? 'system' : (themeMode === 'system') ? 'light' : 'dark';
+  try{ localStorage.setItem('immich_drop_theme', themeMode); }catch{}
   applyTheme(themeMode);
   updateThemeIcon();
 }
@@ -164,23 +168,6 @@ function render(){
 
     itemsEl.appendChild(card);
   });
-
-  // Attach retry handlers for errored items
-  try {
-    itemsEl.querySelectorAll('.btnRetry').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        e.preventDefault();
-        const id = btn.getAttribute('data-id');
-        const it = items.find(x => x.id === id);
-        if (!it) return;
-        it.status = 'queued';
-        it.progress = 0;
-        try { delete it.message; } catch {}
-        render();
-        runQueue();
-      });
-    });
-  } catch {}
 
   const c = {queued:0,uploading:0,done:0,dup:0,err:0};
   for(const it of items){

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -23,7 +23,10 @@
   }
 
   function initDarkMode(){
-    themeMode = 'system';
+    try{
+      const saved = localStorage.getItem('immich_drop_theme');
+      themeMode = (saved === 'light' || saved === 'dark') ? saved : 'system';
+    }catch{ themeMode = 'system'; }
     applyTheme(themeMode);
     updateThemeIcon();
     if (prefersDark && prefersDark.addEventListener) {
@@ -35,6 +38,7 @@
 
   function toggleDarkMode() {
     themeMode = (themeMode === 'dark') ? 'system' : (themeMode === 'system') ? 'light' : 'dark';
+    try{ localStorage.setItem('immich_drop_theme', themeMode); }catch{}
     applyTheme(themeMode);
     updateThemeIcon();
   }

--- a/frontend/menu.js
+++ b/frontend/menu.js
@@ -92,9 +92,9 @@
       qrImg.src = '/api/qr?text='+encodeURIComponent(link);
       if (j && j.token) { try { LAST_CREATED_TOKEN = j.token; } catch(e2){} }
       try { await loadInvites(); } catch(e2){}
+      days.value = '';
+      passwordInput.value = '';
     }catch(err){ showResult('err'); }
-    days.value = '';
-    passwordInput.value = '';
   };
 
   btnCopy.onclick = function(){
@@ -250,7 +250,7 @@
           if (items.length){
             var tbl = '<table class="data-table"><thead><tr><th>When</th><th>IP</th><th>Filename</th><th>Size</th></tr></thead><tbody>';
             items.forEach(function(it){
-              tbl += '<tr><td>'+escAttr(new Date(it.uploadedAt).toLocaleString())+'</td><td>'+escAttr(it.ip)+'</td><td>'+escAttr(it.filename)+'</td><td>'+escAttr(formatBytes(it.size||0).toLocaleString())+'</td></tr>';
+              tbl += '<tr><td>'+escAttr(new Date(it.uploadedAt).toLocaleString())+'</td><td>'+escAttr(it.ip)+'</td><td>'+escAttr(it.filename)+'</td><td>'+escAttr(formatBytes(it.size||0))+'</td></tr>';
             });
             tbl += '</tbody></table>';
             body.innerHTML = tbl;

--- a/frontend/url-uploader.js
+++ b/frontend/url-uploader.js
@@ -21,9 +21,9 @@ class UrlUploader {
 
     // NOTE: This render method uses innerHTML to build its own UI shell.
     // All dynamic user content (filenames, URLs, platform names) injected
-    // later uses escapeHtml() or textContent -- see addResult() and
-    // loadSupportedPlatforms(). This initial template contains only
-    // static markup with no user-supplied data.
+    // later uses textContent -- see addResult() and loadSupportedPlatforms().
+    // This initial template contains only static markup with no
+    // user-supplied data.
     render() {
         this.container.innerHTML =
             '<div class="url-uploader">'
@@ -319,11 +319,6 @@ class UrlUploader {
         }
     }
 
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    }
 }
 
 // Export for module usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,13 +13,11 @@ idna==3.18
 itsdangerous==2.2.0
 pillow==12.3.0
 pydantic==2.13.4
-pydantic_core==2.47.0
+pydantic_core==2.46.4
 python-dotenv==1.2.2
 python-multipart==0.0.32
 PyYAML==6.0.3
 qrcode==8.2
-requests==2.34.2
-requests-toolbelt==1.0.0
 sniffio==1.3.1
 starlette==1.3.1
 typing-inspection==0.4.2

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.7.2"
+VERSION = "1.8.0"


### PR DESCRIPTION
## Summary

Restores uploads against Immich v3 (broken since the server upgrade to 3.0.2 with 400 Validation failed) and consolidates the codebase.

### Fixes
- Immich v3 upload compatibility: stop sending deviceAssetId/deviceId/originalFileName (removed from AssetMediaCreateDto; Zod rejects unknown fields); emit fileCreatedAt/fileModifiedAt as ISO-8601 with UTC offset (naive EXIF/mtime timestamps also failed validation)
- Un-awaited get_or_create_album when creating invites by album name
- URL uploads read a non-existent duplicate field instead of status == duplicate
- Ping probed removed /server-info endpoint
- pydantic_core pinned back to 2.46.4 (2.47.0 from the dependabot group bump is not installable with pydantic 2.13.4)

### Refactor
- Single async Immich client (app/immich_client.py) replaces three duplicate upload implementations; requests/requests-toolbelt dropped (no more blocking calls in async handlers)
- Central sqlite module (app/db.py); all DDL at startup
- Chunk completion streams parts to one file; background job cleanup; third-party log noise capped at WARNING; CORS wildcard+credentials combo removed

### Frontend follow-ups to community PRs
- #44: theme mode now persists in localStorage
- #50: invite form clears only on success
- #51: drop no-op toLocaleString
- Dead retry handler and unused escapeHtml removed

### Verification
- All upload paths (whole-file, chunked, batch, invite-gated) exercised against a stub server enforcing the exact v3 Zod field allowlist and datetime pattern
- Docker image builds (linux/amd64) and container serves /api/config with v1.8.0