### PR TITLE
1.8.1: real browser-to-server upload progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.1] - 2026-07-11
+
+### Fixed
+- Upload progress mislabeling: the browser-to-server transfer displayed as a
+  stuck "Checking" phase because fetch() has no upload-progress API. Whole-file
+  uploads now use XMLHttpRequest with upload.onprogress and show a real
+  "Sending to server... N%" phase; "Checking" now only covers the actual
+  sub-second duplicate check. Progress restarts per phase (sending ->
+  checking -> uploading) instead of being globally monotonic.
+
+### Changed
+- httpx request logging restored to INFO (one line per Immich API call) for
+  timing visibility; the WARNING cap from 1.8.0 remains for the noisy
+  libraries (PIL, python_multipart, httpcore, urllib3, websockets).
+
 ## [1.8.0] - 2026-07-10
 
 ### Fixed

--- a/app/app.py
+++ b/app/app.py
@@ -84,9 +84,11 @@ SETTINGS: Settings = load_settings()
 # Basic logging setup using settings
 logging.basicConfig(level=SETTINGS.log_level, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 # Third-party libraries log large volumes at DEBUG; keep them at WARNING
-# regardless of the app LOG_LEVEL.
-for _noisy in ("PIL", "python_multipart", "httpcore", "httpx", "urllib3", "websockets", "charset_normalizer"):
+# regardless of the app LOG_LEVEL. httpx stays at INFO: its one-line-per-request
+# entries are the only record of individual Immich API calls.
+for _noisy in ("PIL", "python_multipart", "httpcore", "urllib3", "websockets", "charset_normalizer"):
     logging.getLogger(_noisy).setLevel(logging.WARNING)
+logging.getLogger("httpx").setLevel(logging.INFO)
 logger = logging.getLogger("immich_drop")
 
 # Cookie-based session for short-lived auth token storage (no persistence)

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -42,7 +42,8 @@ let items = [];
 let socket;
 
 // Status precedence: never regress (e.g., uploading -> done shouldn't go back to uploading)
-const STATUS_ORDER = { queued: 0, checking: 1, uploading: 2, duplicate: 3, done: 3, error: 4 };
+// 'sending' is the browser->server transfer; 'checking'/'uploading' arrive via WS from the server.
+const STATUS_ORDER = { queued: 0, sending: 1, checking: 2, uploading: 3, duplicate: 4, done: 4, error: 5 };
 const FINAL_STATES = new Set(['done','duplicate','error']);
 
 // --- Dark mode ---
@@ -129,7 +130,9 @@ function render(){
     var fillClass = it.status==='done'?'upload-item__fill--done':it.status==='duplicate'?'upload-item__fill--dup':it.status==='error'?'upload-item__fill--err':'';
     var displayStatus = (it.status==='uploading' && it.progress >= 100) ? 'done' : it.status;
     var pct = Math.max(it.progress, (it.status==='done'||it.status==='duplicate'||it.status==='error')?100:it.progress);
-    var statusText = it.status==='uploading' ? (it.progress >= 100 ? 'Processing...' : 'Uploading... '+it.progress+'%') : it.status.charAt(0).toUpperCase()+it.status.slice(1);
+    var statusText = it.status==='uploading' ? (it.progress >= 100 ? 'Processing...' : 'Uploading... '+it.progress+'%')
+      : it.status==='sending' ? (it.progress >= 100 ? 'Waiting for server...' : 'Sending to server... '+it.progress+'%')
+      : it.status.charAt(0).toUpperCase()+it.status.slice(1);
 
     var card = document.createElement('div');
     card.className = 'upload-item';
@@ -172,7 +175,7 @@ function render(){
   const c = {queued:0,uploading:0,done:0,dup:0,err:0};
   for(const it of items){
     if(['queued','checking'].includes(it.status)) c.queued++;
-    if(it.status==='uploading') c.uploading++;
+    if(it.status==='uploading' || it.status==='sending') c.uploading++;
     if(it.status==='done') c.done++;
     if(it.status==='duplicate') c.dup++;
     if(it.status==='error') c.err++;
@@ -201,11 +204,13 @@ function openSocket(){
     if (inc < cur) {
       // ignore regressive status updates
     } else {
+      const phaseChanged = inc > cur;
       it.status = status;
-    }
-    if (typeof progress==='number') {
-      // never decrease progress
-      it.progress = Math.max(it.progress || 0, progress);
+      if (typeof progress==='number') {
+        // never decrease progress within a phase, but let a new phase
+        // (sending -> checking -> uploading) restart its own bar
+        it.progress = phaseChanged ? progress : Math.max(it.progress || 0, progress);
+      }
     }
     if (message) it.message = message;
     if (FINAL_STATES.has(it.status)) {
@@ -224,7 +229,8 @@ async function runQueue(){
     if(inflight >= 3) return; // client-side throttle; server handles uploads regardless
     const next = items.find(i => i.status==='queued');
     if(!next) return;
-    next.status='checking';
+    next.status='sending';
+    next.progress=0;
     render();
     inflight++;
     try{
@@ -245,6 +251,24 @@ async function runQueue(){
   for(let i=0;i<3;i++) runNext();
 }
 
+// POST a FormData via XHR so the browser->server transfer reports progress
+// (fetch has no upload-progress API).
+function postForm(url, form, onProgress){
+  return new Promise(function(resolve, reject){
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+    xhr.responseType = 'json';
+    if (xhr.upload && onProgress) {
+      xhr.upload.onprogress = function(e){
+        if (e.lengthComputable) onProgress(Math.round(e.loaded * 100 / e.total));
+      };
+    }
+    xhr.onload = function(){ resolve({ ok: xhr.status >= 200 && xhr.status < 300, body: xhr.response || {} }); };
+    xhr.onerror = function(){ reject(new Error('Network error')); };
+    xhr.send(form);
+  });
+}
+
 async function uploadWhole(next){
   const form = new FormData();
   form.append('file', next.file);
@@ -253,8 +277,19 @@ async function uploadWhole(next){
   form.append('last_modified', next.file.lastModified || '');
   if (INVITE_TOKEN) form.append('invite_token', INVITE_TOKEN);
   form.append('fingerprint', FINGERPRINT);
-  const res = await fetch('/api/upload', { method:'POST', body: form });
-  const body = await res.json().catch(()=>({}));
+  let lastPct = -1;
+  const res = await postForm('/api/upload', form, function(pct){
+    if (pct === lastPct) return;
+    lastPct = pct;
+    // only drive the bar while still in the sending phase; once WS
+    // updates arrive (checking/uploading) they own the item
+    if ((STATUS_ORDER[next.status] ?? 0) <= STATUS_ORDER.sending) {
+      next.status = 'sending';
+      next.progress = pct;
+      render();
+    }
+  });
+  const body = res.body || {};
   if(!res.ok && next.status!=='error'){
     next.status='error';
     next.message = body.error || 'Upload failed';

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.8.0"
+VERSION = "1.8.1"


### PR DESCRIPTION
## Summary
Follow-up to a log-analysis finding: the upload UI showed a stuck 'Checking' phase during the browser-to-server file transfer. fetch() has no upload-progress API, so the item stayed at 'checking 2%' until the whole body reached the server. On large files or slow uplinks this reads as a hung duplicate check.

## Change
- Whole-file uploads use XMLHttpRequest with upload.onprogress and a distinct 'Sending to server... N%' phase; 'Checking' now covers only the actual sub-second duplicate check
- Progress restarts per phase (sending -> checking -> uploading)
- httpx request logging restored to INFO for per-call timing visibility (noisy libs stay at WARNING)

## Verification
Drove a 60 MB upload through the real app in a browser; recorded phase sequence: sending 0->39->100%, checking 2%, uploading 0->100%, done. Confirmed httpx INFO request lines are logged again.