### PR TITLE
Fix typo in Docker image name for immich-drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ version: "3.9"
 
 services:
   immich-drop:
-    image: ttlequas0/immich-drop:latest
+    image: ttlequals0/immich-drop:latest
     pull_policy: always
     container_name: immich-drop
     restart: unless-stopped


### PR DESCRIPTION
small typo in the docker compose.  there is no "issues" for this repo so I'm putting it in as a PR.