### PR TITLE
feat: Configuration of TEST CONNECTION

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,9 @@ INSTAGRAM_YTDLP_FALLBACK=false
 
 # Disable social media uploads (optional) — enabled by default
 SOCIAL_MEDIA_UPLOADS_ENABLED=true
+
+# "Test connection" button. Disable to hide the button and stop /api/ping from
+# probing Immich; set SHOW_HOSTNAME=false to keep the button but hide the
+# upstream Immich URL from the banner.
+TEST_CONNECTION_ENABLED=true
+TEST_CONNECTION_SHOW_HOSTNAME=true

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ services:
       # App internals
       SESSION_SECRET: ${SESSION_SECRET}
 
+      # disable test connection button and API
+      TESTCONNECTION: false
+
+      # or just disable showing the hostname in banner & API
+      TESTCONNECTION_SHOW_HOSTNAME: false
+
     # Expose the app on the host
     ports:
       - 8080:8080
@@ -313,6 +319,8 @@ LOG_LEVEL=DEBUG
 CHUNKED_UPLOADS_ENABLED=true
 CHUNK_SIZE_MB=95
 
+# disable showing hostname in Test connection ("ping") API for privacy reasons
+TESTCONNECTION_SHOW_HOSTNAME=false
 ```
 
 
@@ -343,6 +351,7 @@ You can keep a checked‑in `/.env.example` with the keys above for onboarding.
 - The Immich API key remains **server‑side**; the browser never sees it.  
 - No browsing of uploaded media; only ephemeral session state is shown.  
 - Run behind HTTPS with a reverse proxy and restrict CORS to your domain(s).
+- For extra privacy set `TESTCONNECTION_SHOW_HOSTNAME=false` to hide the upstream Immich server hostname from the user or `TESTCONNECTION=false` to disable the **test connection button** completely.
 
 ## Usage flow
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ services:
       SESSION_SECRET: ${SESSION_SECRET}
 
       # disable test connection button and API
-      TESTCONNECTION: false
+      TEST_CONNECTION_ENABLED: false
 
       # or just disable showing the hostname in banner & API
-      TESTCONNECTION_SHOW_HOSTNAME: false
+      TEST_CONNECTION_SHOW_HOSTNAME: false
 
     # Expose the app on the host
     ports:
@@ -320,7 +320,7 @@ CHUNKED_UPLOADS_ENABLED=true
 CHUNK_SIZE_MB=95
 
 # disable showing hostname in Test connection ("ping") API for privacy reasons
-TESTCONNECTION_SHOW_HOSTNAME=false
+TEST_CONNECTION_SHOW_HOSTNAME=false
 ```
 
 
@@ -351,7 +351,7 @@ You can keep a checked‑in `/.env.example` with the keys above for onboarding.
 - The Immich API key remains **server‑side**; the browser never sees it.  
 - No browsing of uploaded media; only ephemeral session state is shown.  
 - Run behind HTTPS with a reverse proxy and restrict CORS to your domain(s).
-- For extra privacy set `TESTCONNECTION_SHOW_HOSTNAME=false` to hide the upstream Immich server hostname from the user or `TESTCONNECTION=false` to disable the **test connection button** completely.
+- For extra privacy set `TEST_CONNECTION_SHOW_HOSTNAME=false` to hide the upstream Immich server hostname from the user or `TEST_CONNECTION_ENABLED=false` to disable the **test connection button** completely.
 
 ## Usage flow
 

--- a/app/app.py
+++ b/app/app.py
@@ -393,11 +393,15 @@ async def favicon() -> Response:
 
 @app.post("/api/ping")
 async def api_ping() -> dict:
-    """Connectivity test endpoint used by the UI to display a temporary banner."""
+    if not SETTINGS.testconnection:
+        return {}
+
+    ok = await immich_ping()
+
     return {
-        "ok": await immich_ping(),
-        "base_url": SETTINGS.normalized_base_url,
-        "album_name": SETTINGS.album_name if SETTINGS.album_name else None
+        "ok": ok,
+        "base_url": SETTINGS.normalized_base_url if SETTINGS.testconnection_show_hostname else None,
+        "album_name": SETTINGS.album_name if SETTINGS.testconnection_show_hostname else None,
     }
 
 @app.get("/api/config")
@@ -409,6 +413,7 @@ async def api_config() -> dict:
         "chunk_size_mb": SETTINGS.chunk_size_mb,
         "version": VERSION,
         "social_media_uploads": SETTINGS.social_media_uploads,
+        "testconnection": SETTINGS.testconnection,
     }
 
 @app.websocket("/ws")

--- a/app/app.py
+++ b/app/app.py
@@ -393,15 +393,13 @@ async def favicon() -> Response:
 
 @app.post("/api/ping")
 async def api_ping() -> dict:
-    if not SETTINGS.testconnection:
-        return {}
-
-    ok = await immich_ping()
-
+    """Connectivity test endpoint used by the UI to display a temporary banner."""
+    if not SETTINGS.test_connection_enabled:
+        return {"ok": False, "disabled": True}
     return {
-        "ok": ok,
-        "base_url": SETTINGS.normalized_base_url if SETTINGS.testconnection_show_hostname else None,
-        "album_name": SETTINGS.album_name if SETTINGS.testconnection_show_hostname else None,
+        "ok": await immich_ping(),
+        "base_url": SETTINGS.normalized_base_url if SETTINGS.test_connection_show_hostname else None,
+        "album_name": SETTINGS.album_name if SETTINGS.album_name else None,
     }
 
 @app.get("/api/config")
@@ -413,7 +411,7 @@ async def api_config() -> dict:
         "chunk_size_mb": SETTINGS.chunk_size_mb,
         "version": VERSION,
         "social_media_uploads": SETTINGS.social_media_uploads,
-        "testconnection": SETTINGS.testconnection,
+        "test_connection_enabled": SETTINGS.test_connection_enabled,
     }
 
 @app.websocket("/ws")

--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,8 @@ class Settings:
     download_concurrency: int = 1
     instagram_ytdlp_fallback: bool = False
     social_media_uploads: bool = True
+    testconnection_show_hostname: bool = True
+    testconnection: bool = True
 
     @property
     def normalized_base_url(self) -> str:
@@ -71,6 +73,8 @@ def load_settings() -> Settings:
         download_concurrency = 1
     instagram_ytdlp_fallback = as_bool(os.getenv("INSTAGRAM_YTDLP_FALLBACK", "false"), False)
     social_media_uploads = as_bool(os.getenv("SOCIAL_MEDIA_UPLOADS_ENABLED", "true"), True)
+    testconnection_show_hostname = as_bool(os.getenv("TESTCONNECTION_SHOW_HOSTNAME", "true"), True)
+    testconnection = as_bool(os.getenv("TESTCONNECTION", "true"), True)
     return Settings(
         immich_base_url=base,
         immich_api_key=api_key,
@@ -88,4 +92,6 @@ def load_settings() -> Settings:
         download_concurrency=download_concurrency,
         instagram_ytdlp_fallback=instagram_ytdlp_fallback,
         social_media_uploads=social_media_uploads,
+        testconnection_show_hostname=testconnection_show_hostname,
+        testconnection=testconnection,
     )

--- a/app/config.py
+++ b/app/config.py
@@ -29,8 +29,8 @@ class Settings:
     download_concurrency: int = 1
     instagram_ytdlp_fallback: bool = False
     social_media_uploads: bool = True
-    testconnection_show_hostname: bool = True
-    testconnection: bool = True
+    test_connection_enabled: bool = True
+    test_connection_show_hostname: bool = True
 
     @property
     def normalized_base_url(self) -> str:
@@ -73,8 +73,8 @@ def load_settings() -> Settings:
         download_concurrency = 1
     instagram_ytdlp_fallback = as_bool(os.getenv("INSTAGRAM_YTDLP_FALLBACK", "false"), False)
     social_media_uploads = as_bool(os.getenv("SOCIAL_MEDIA_UPLOADS_ENABLED", "true"), True)
-    testconnection_show_hostname = as_bool(os.getenv("TESTCONNECTION_SHOW_HOSTNAME", "true"), True)
-    testconnection = as_bool(os.getenv("TESTCONNECTION", "true"), True)
+    test_connection_enabled = as_bool(os.getenv("TEST_CONNECTION_ENABLED", "true"), True)
+    test_connection_show_hostname = as_bool(os.getenv("TEST_CONNECTION_SHOW_HOSTNAME", "true"), True)
     return Settings(
         immich_base_url=base,
         immich_api_key=api_key,
@@ -92,6 +92,6 @@ def load_settings() -> Settings:
         download_concurrency=download_concurrency,
         instagram_ytdlp_fallback=instagram_ytdlp_fallback,
         social_media_uploads=social_media_uploads,
-        testconnection_show_hostname=testconnection_show_hostname,
-        testconnection=testconnection,
+        test_connection_enabled=test_connection_enabled,
+        test_connection_show_hostname=test_connection_show_hostname,
     )

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -100,6 +100,9 @@ initDarkMode();
         CFG.chunked_uploads_enabled = !!j.chunked_uploads_enabled;
         const n = parseInt(j.chunk_size_mb, 10);
         if (!Number.isNaN(n) && n > 0) CFG.chunk_size_mb = n;
+        // Button ships hidden; only reveal it when the endpoint is live
+        const bp = document.getElementById('btnPing');
+        if (bp && j.test_connection_enabled) bp.classList.remove('hidden');
       }
     }
   }catch{}
@@ -401,10 +404,8 @@ if (btnPing) btnPing.onclick = async () => {
     pingStatus.textContent = j.ok ? 'Connected' : 'No connection';
     pingStatus.className = 'ml-2 text-sm ' + (j.ok ? 'text-green-600' : 'text-red-600');
     if(j.ok){
-      let bannerText = "Connected to Immich";
-      
-      if (j.base_url)
-        bannerText += ` at ${j.base_url}`;
+      let bannerText = 'Connected to Immich';
+      if (j.base_url) bannerText += ` at ${j.base_url}`;
       if(j.album_name) {
         bannerText += ` | Uploading to album: "${j.album_name}"`;
       }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -401,7 +401,10 @@ if (btnPing) btnPing.onclick = async () => {
     pingStatus.textContent = j.ok ? 'Connected' : 'No connection';
     pingStatus.className = 'ml-2 text-sm ' + (j.ok ? 'text-green-600' : 'text-red-600');
     if(j.ok){
-      let bannerText = `Connected to Immich at ${j.base_url}`;
+      let bannerText = "Connected to Immich";
+      
+      if (j.base_url)
+        bannerText += ` at ${j.base_url}`;
       if(j.album_name) {
         bannerText += ` | Uploading to album: "${j.album_name}"`;
       }

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -67,7 +67,8 @@
           pingStatus.className = 'ml-2 text-sm ' + (j.ok ? 'text-green-600' : 'text-red-600');
         }
         if(j.ok){
-          let text = `Connected to Immich at ${j.base_url}`;
+          let text = `Connected to Immich`;
+          if (j.base_url) text +=  ` at ${j.base_url}`;
           if (j.album_name) text += ` | Uploading to album: "${j.album_name}"`;
           showBanner(text, 'ok');
         }
@@ -87,9 +88,13 @@
         const enabled = !!(j && j.public_upload_page_enabled);
         if (linkPublic) linkPublic.classList.toggle('hidden', !enabled);
         if (linkHome) linkHome.classList.toggle('hidden', !enabled);
+
+        if (j.testconnection && btnPing) btnPing.classList.toggle('hidden', false); 
+
       }catch{
         if (linkPublic) linkPublic.classList.add('hidden');
         if (linkHome) linkHome.classList.add('hidden');
+        if (btnPing) btnPing.classList.add('hidden'); 
       }
     })();
   }

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -67,8 +67,8 @@
           pingStatus.className = 'ml-2 text-sm ' + (j.ok ? 'text-green-600' : 'text-red-600');
         }
         if(j.ok){
-          let text = `Connected to Immich`;
-          if (j.base_url) text +=  ` at ${j.base_url}`;
+          let text = 'Connected to Immich';
+          if (j.base_url) text += ` at ${j.base_url}`;
           if (j.album_name) text += ` | Uploading to album: "${j.album_name}"`;
           showBanner(text, 'ok');
         }
@@ -88,13 +88,12 @@
         const enabled = !!(j && j.public_upload_page_enabled);
         if (linkPublic) linkPublic.classList.toggle('hidden', !enabled);
         if (linkHome) linkHome.classList.toggle('hidden', !enabled);
-
-        if (j.testconnection && btnPing) btnPing.classList.toggle('hidden', false); 
-
+        // Button ships hidden; only reveal it when the endpoint is live
+        if (btnPing && j.test_connection_enabled) btnPing.classList.remove('hidden');
       }catch{
         if (linkPublic) linkPublic.classList.add('hidden');
         if (linkHome) linkHome.classList.add('hidden');
-        if (btnPing) btnPing.classList.add('hidden'); 
+        if (btnPing) btnPing.classList.add('hidden');
       }
     })();
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,7 +26,7 @@
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-2V4c4.418 0 8 3.582 8 8s-3.582 8-8 8z"/>
           </svg>
         </button>
-        <button id="btnPing" class="btn">Test connection</button>
+        <button id="btnPing" class="btn hidden">Test connection</button>
         <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>

--- a/frontend/invite.html
+++ b/frontend/invite.html
@@ -29,7 +29,7 @@
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-2V4c4.418 0 8 3.582 8 8s-3.582 8-8 8z"/>
           </svg>
         </button>
-        <button id="btnPing" class="btn">Test connection</button>
+        <button id="btnPing" class="btn hidden">Test connection</button>
         <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -26,7 +26,7 @@
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-2V4c4.418 0 8 3.582 8 8s-3.582 8-8 8z"/>
           </svg>
         </button>
-        <button id="btnPing" class="btn">Test connection</button>
+        <button id="btnPing" class="btn hidden">Test connection</button>
         <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -27,7 +27,7 @@
             <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zm0-2V4c4.418 0 8 3.582 8 8s-3.582 8-8 8z"/>
           </svg>
         </button>
-        <button id="btnPing" class="btn">Test connection</button>
+        <button id="btnPing" class="btn hidden">Test connection</button>
         <span id="pingStatus" class="text-sm text-secondary"></span>
       </div>
     </header>


### PR DESCRIPTION
I found the "test connection" button disturbed me...

a) my home users don't really care about the architecture and hence don't want to test the connection in production..

b) the banner gave away connection info of the upstream immich server, which wanted to conceal

Hence this PR, which adds two new configuration options
```
# disable test connection button and API
TESTCONNECTION: false

# or just disable showing the hostname in banner & API
TESTCONNECTION_SHOW_HOSTNAME: false
```

If not set, both values default to true, the current way of working.