### PR TITLE
feature: Added healthcheck to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,7 @@ ENV HOST=0.0.0.0 \
 
 EXPOSE 8080
 
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/').read()"
+
 CMD ["python", "main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ ENV HOST=0.0.0.0 \
 
 EXPOSE 8080
 
+# Reads PORT so the check follows a non-default port; /api/config is a cheap
+# JSON response that never redirects, unlike / which 302s to /login when the
+# public upload page is disabled.
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/').read()"
+  CMD python -c 'import os,urllib.request; urllib.request.urlopen("http://127.0.0.1:%s/api/config" % os.getenv("PORT","8080"), timeout=3).read()'
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
The DOCS outline a healthcheck that is recommended.
However you can now put it into the Dockerfile, so it automatically becomes part of the image, instead of having to specify it manually in your own compose file.