### PR TITLE
build(deps): bump charset-normalizer, idna, python-dotenv, uvicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Dependencies
+- charset-normalizer 3.5.0 -> 3.5.1, idna 3.18 -> 3.19,
+  python-dotenv 1.2.2 -> 1.2.3, uvicorn 0.52.3 -> 0.52.4.
+- pydantic_core held at 2.46.4. Dependabot grouped 2.48.0 into the same bump
+  (#86), which cannot resolve: pydantic 2.13.4 pins pydantic-core==2.46.4
+  exactly. Same conflict that closed #75.
+
 ## [1.8.2] - 2026-08-17
 
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.8.0
 anyio==4.14.2
 certifi==2026.7.22
-charset-normalizer==3.5.0
+charset-normalizer==3.5.1
 click==8.4.2
 colorama==0.4.6
 fastapi==0.141.1
@@ -9,12 +9,12 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.8.0
 httpx==0.28.1
-idna==3.18
+idna==3.19
 itsdangerous==2.2.0
 pillow==12.3.0
 pydantic==2.13.4
 pydantic_core==2.46.4
-python-dotenv==1.2.2
+python-dotenv==1.2.3
 python-multipart==0.0.32
 PyYAML==6.0.3
 qrcode==8.2
@@ -23,7 +23,7 @@ starlette==1.6.0
 typing-inspection==0.4.4
 typing_extensions==4.16.0
 urllib3==2.7.0
-uvicorn==0.52.3
+uvicorn==0.52.4
 watchfiles==1.2.0
 websockets==16.1
 yt-dlp[default,curl-cffi]==2026.7.4


### PR DESCRIPTION
Replaces #86, which could not resolve.

Dependabot grouped `pydantic_core` 2.48.0 in with four unrelated bumps. pydantic 2.13.4 pins `pydantic-core==2.46.4` exactly, so the group as a whole was uninstallable:

```
ERROR: Cannot install pydantic==2.13.4 and pydantic_core==2.48.0 because these
package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

This branch takes the four bumps that do resolve and holds `pydantic_core` at 2.46.4. Same call that was made on #75.

## Changes

| Package | From | To |
|---|---|---|
| charset-normalizer | 3.5.0 | 3.5.1 |
| idna | 3.18 | 3.19 |
| python-dotenv | 1.2.2 | 1.2.3 |
| uvicorn | 0.52.3 | 0.52.4 |

## Verification

- `pip install --only-binary=:all: -r requirements.txt` resolves cleanly, with `pydantic_core` landing on 2.46.4 as intended.
- Booted the app under uvicorn 0.52.4 and drove a full session: `/api/config` 200, WebSocket connect, session registered in `SessionHub`, server-pushed progress frame received.

```
websockets 16.1 | uvicorn 0.52.4
GET /api/config -> 200
hub sessions -> ['sess-abc']
server->client progress frame: {"item_id": "item1", "status": "uploading", "progress": 42, ...}
RESULT: PASS
```

The CHANGELOG entry is filed under `## [Unreleased]` since no version has been cut for this cycle yet.
