### PR TITLE
chore: release v1.9.1 - shared links, auth fixes, 3.14 base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.9.0] - 2026-08-25
 
 ### Added
 - Immich native Shared Links can be used for uploads (#87, thanks @knom). A link
   created in Immich itself (Sharing -> Create link with "Allow public user to
   upload") works at `/invite/<key>` with no local invite record; name, password,
   expiry and album are read live from Immich, and the upload and album-add calls
-  authenticate with the share key alone.
+  authenticate with the share key alone. The existing invite page renders it
+  with no frontend change.
+
+### Fixed
+- TikTok no longer needs the `--referer` workaround added in 1.8.2. yt-dlp
+  2026.8.19 replaced the bare webpage fetch with browser impersonation and
+  generated headers, which fixes the "Unexpected response from webpage request"
+  failure at its source. Verified on one post with a single variable changed:
+  2026.7.4 fails without the flag and succeeds with it, 2026.8.19 succeeds
+  either way. The flag and its tracking comment are removed.
 
 ### Security
 - A share password unlocked the link for every visitor, not just the one who
@@ -20,17 +29,25 @@ All notable changes to this project will be documented in this file.
   first correct password therefore authorized everyone until the process
   restarted. The login now runs on a throwaway client and the token is held in
   the visitor's own session, sent explicitly as a Cookie header.
-- Chunk upload endpoints accepted any unrecognized token again. Tokens that are
-  not local invites were passed through `_guard_chunked_upload` and only
-  validated at completion, which reopened the pre-validation hole closed in
-  1.8.2. The guard now validates a non-invite token against Immich as a Shared
-  Link key before any bytes reach /data.
+- Chunk upload endpoints accepted any unrecognized token. Tokens that are not
+  local invites were passed through `_guard_chunked_upload` and only validated
+  at completion, which reopened the pre-validation hole closed in 1.8.2. The
+  guard now validates a non-invite token against Immich as a Shared Link key
+  before any bytes reach /data.
+
+### Changed
+- Base image moved from `python:3.11-alpine` to `python:3.14-alpine` (#83).
+  Every pinned dependency resolves to a cp314 musl wheel, so the image still
+  gains no compiler. Trivy reports 0 HIGH/CRITICAL, and the image is slightly
+  smaller than the 3.11 build made the same way.
+
 ### Dependencies
-- charset-normalizer 3.5.0 -> 3.5.1, idna 3.18 -> 3.19,
-  python-dotenv 1.2.2 -> 1.2.3, uvicorn 0.52.3 -> 0.52.4.
-- pydantic_core held at 2.46.4. Dependabot grouped 2.48.0 into the same bump
-  (#86), which cannot resolve: pydantic 2.13.4 pins pydantic-core==2.46.4
-  exactly. Same conflict that closed #75.
+- yt-dlp 2026.7.4 -> 2026.8.19 (#85), websockets 16.1 -> 17.0.1 (#81),
+  charset-normalizer 3.5.0 -> 3.5.1, idna 3.18 -> 3.19,
+  python-dotenv 1.2.2 -> 1.2.3, uvicorn 0.52.3 -> 0.52.4 (#88).
+- pydantic_core held at 2.46.4. Dependabot grouped 2.48.0 into #86, which
+  cannot resolve: pydantic 2.13.4 pins pydantic-core==2.46.4 exactly. #86 was
+  closed and replaced by #88. Same conflict that closed #75.
 
 ## [1.8.2] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.9.1] - 2026-08-25
+
+### Fixed
+- Long filenames broke out of the upload result cards. A name with no wrap
+  opportunity pushed the row past the card edge and shoved the platform label
+  outside the right border. Two causes: `url-uploader.js` built its own result
+  row with inline styles instead of the `.upload-item__header` classes the
+  file-upload rows use, and those shared classes set `overflow: hidden` and
+  `text-overflow: ellipsis` on an inline `<span>`, where `overflow` does not
+  apply and both declarations did nothing. The name is now a flex item, which
+  blockifies it and makes the ellipsis work, and both upload paths share one
+  set of classes. The file-upload rows had the same latent bug.
+- Upload status sat in two different places within one list, right-aligned
+  when it fit beside the filename and left-aligned when it wrapped below.
+  It now holds the same right-hand column either way, so a list of rows stays
+  scannable.
+
 ## [1.9.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ In addition to invite links created in this app's admin menu, you can hand out a
 
 This app never stores the album, password, or expiry for these links -- every request asks Immich directly (`GET /shared-links/me`, `POST /shared-links/login`), the same key-only trust model [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy) uses for read-only viewing. The upload and album-add calls authenticate with the share key itself, which Immich grants upload access to when `allowUpload` is set. `IMMICH_API_KEY` is still used for the duplicate check that runs before every upload, so it remains required.
 
-If the link is password-protected, Immich's unlock token is held in your browser session on this app, scoped to you -- entering the password does not unlock the link for anyone else.
+If the link is password-protected, Immich's unlock token is held in your browser session on this app, scoped to you, so entering the password does not unlock the link for anyone else.
 
 ---
 
@@ -277,7 +277,7 @@ immich_drop/
 
 ## Requirements
 
-- **Python** 3.11
+- **Python** 3.14
 - An **Immich** server + **API key**
 - **gallery-dl** and **yt-dlp** (installed automatically in Docker image)
 

--- a/app/url_downloader.py
+++ b/app/url_downloader.py
@@ -564,11 +564,8 @@ async def download_from_url(
 
     # Platform-specific options
     if platform == 'tiktok':
-        # TikTok blocks webpage requests with no Referer (yt-dlp/yt-dlp#17403).
-        # Remove once the upstream fix (#17437) ships.
         cmd.extend([
             "--format", "best",
-            "--referer", "https://www.tiktok.com/",
         ])
     elif platform == 'instagram':
         cmd.extend([

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -143,13 +143,14 @@ function render(){
     var header = document.createElement('div');
     header.className = 'upload-item__header';
     var left = document.createElement('div');
-    left.className = 'min-w-0';
+    left.className = 'upload-item__meta';
     var nameEl = document.createElement('span');
     nameEl.className = 'upload-item__name';
+    nameEl.title = it.name;
     nameEl.textContent = it.name;
     var sizeEl = document.createElement('span');
     sizeEl.className = 'upload-item__size';
-    sizeEl.textContent = ' ('+human(it.size)+')';
+    sizeEl.textContent = '('+human(it.size)+')';
     left.appendChild(nameEl);
     left.appendChild(sizeEl);
     var statusEl = document.createElement('div');

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -405,6 +405,8 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
   letter-spacing: 0.04em;
   padding: 3px 8px;
   border-radius: 6px;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 .badge--green { background: var(--green-bg); color: var(--green-text); }
 .badge--red { background: var(--red-bg); color: var(--red-text); }
@@ -435,11 +437,30 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 6px 8px;
+  min-width: 0;
+  /* When the name and the status cannot sit side by side, the status drops to
+     its own line rather than squeezing the name down to a few characters. */
+  flex-wrap: wrap;
+}
+/* Left column: the name truncates, the trailing metadata never does. */
+.upload-item__meta {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  /* Content-sized basis: a name that fits keeps the status beside it, and a
+     name that does not takes the whole line and truncates there. */
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
 }
 .upload-item__name {
   font-weight: 500;
   font-size: 0.875rem;
+  /* Flex blockifies this span, which is what makes text-overflow apply.
+     On an inline span these three properties do nothing and a long
+     unbroken filename pushes the whole row past the card. */
+  flex: 0 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -448,11 +469,19 @@ textarea.input { resize: vertical; font-family: var(--font-mono); font-size: 0.8
 .upload-item__size {
   font-size: 0.75rem;
   color: var(--text-tertiary);
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 .upload-item__status {
   font-size: 0.8125rem;
   font-weight: 500;
   flex-shrink: 0;
+}
+/* Keeps the status in the same right-hand column whether it sits beside the
+   name or wraps below it, so a list of rows stays scannable. */
+.upload-item__header > .upload-item__status,
+.upload-item__header > .badge {
+  margin-left: auto;
 }
 .upload-item__bar {
   height: 4px;

--- a/frontend/url-uploader.js
+++ b/frontend/url-uploader.js
@@ -285,23 +285,25 @@ class UrlUploader {
         const status = result.duplicate ? 'duplicate' : result.status;
         const badgeClass = status === 'duplicate' ? 'badge--amber' : status === 'success' ? 'badge--green' : 'badge--red';
 
-        // Build result element using DOM methods to avoid innerHTML with user data
+        // Build result element using DOM methods to avoid innerHTML with user data.
+        // Uses the same header/meta/name classes as the file-upload rows in
+        // app.js so long filenames truncate instead of widening the card.
         const resultEl = document.createElement('div');
         resultEl.className = 'upload-item';
-        resultEl.style.display = 'flex';
-        resultEl.style.alignItems = 'center';
-        resultEl.style.justifyContent = 'space-between';
+
+        const header = document.createElement('div');
+        header.className = 'upload-item__header';
 
         const left = document.createElement('div');
-        left.style.minWidth = '0';
+        left.className = 'upload-item__meta';
         const nameSpan = document.createElement('span');
-        nameSpan.style.fontWeight = '500';
+        nameSpan.className = 'upload-item__name';
+        nameSpan.title = result.filename;
         nameSpan.textContent = result.filename;
         left.appendChild(nameSpan);
         if (result.platform) {
             const platSpan = document.createElement('span');
-            platSpan.className = 'text-xs text-secondary';
-            platSpan.style.marginLeft = '8px';
+            platSpan.className = 'upload-item__size';
             platSpan.textContent = result.platform;
             left.appendChild(platSpan);
         }
@@ -310,8 +312,9 @@ class UrlUploader {
         badge.className = 'badge ' + badgeClass;
         badge.textContent = result.duplicate ? 'Duplicate' : result.status;
 
-        resultEl.appendChild(left);
-        resultEl.appendChild(badge);
+        header.appendChild(left);
+        header.appendChild(badge);
+        resultEl.appendChild(header);
         resultsDiv.prepend(resultEl);
 
         while (resultsDiv.children.length > 10) {

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.8.2"
+VERSION = "1.9.0"

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version information for immich-drop."""
-VERSION = "1.9.0"
+VERSION = "1.9.1"


### PR DESCRIPTION
## Summary

Cuts 1.9.1. Minor bump because #87 adds a user-facing feature; the extra patch is a UI fix found after 1.9.0 was already built.

Merged into master for this release:

| PR | Change |
|---|---|
| #87 (@knom) | Immich native Shared Links usable for uploads, plus two security fixes on top |
| #85 | yt-dlp 2026.7.4 -> 2026.8.19 |
| #83 | Base image python 3.11-alpine -> 3.14-alpine |
| #81 | websockets 16.1 -> 17.0.1 |
| #88 | charset-normalizer, idna, python-dotenv, uvicorn |

This branch adds on top:

- The TikTok `--referer` workaround from 1.8.2 is removed. yt-dlp 2026.8.19 fixes the extractor at its source.
- README requirements updated to Python 3.14.
- Long filenames no longer break out of the upload result cards (1.9.1).

## Two security fixes worth reading

Both were found reviewing #87 and fixed on that branch before merge.

A share password unlocked the link for every visitor. `POST /shared-links/login` is answered with a Set-Cookie carrying Immich's unlock token, and the call ran on the process-wide `app.state.httpx_client`. httpx stores response cookies on the client that made the request and replays them on every later request to that host, so the first correct password authorized everyone until the process restarted. Login now runs on a throwaway client and the token is held in the visitor's own session.

`_guard_chunked_upload` returned `None` for any token that was not a local invite, so an unrecognized token could write parts to `/data` before validation. That reopened the hole closed in 1.8.2. The guard now validates a non-invite token against Immich as a Shared Link key before accepting bytes.

## The 1.9.1 UI fix

A filename with no wrap opportunity pushed the result row past the card edge and shoved the platform label outside the right border. Two causes:

- `url-uploader.js` built its own row with inline styles instead of the `.upload-item__header` classes the file-upload rows already use, so it had no truncation and no `flex-shrink` on the badge.
- The shared classes were broken too. `overflow: hidden` and `text-overflow: ellipsis` were set on an inline `<span>`, where `overflow` does not apply, so both declarations did nothing. The file-upload rows carried the same latent bug, hidden only because camera filenames are shorter.

Making the name a flex item blockifies it, which is what makes the ellipsis work. Both paths now share one set of classes. Status also held two different positions within one list depending on whether it wrapped; it now stays in the same right-hand column either way.

## Version

1.9.1

Note on tags: `1.9.0` was built, pushed, and deployed before the UI fix was found. That image is still what production ran, so its tag is left alone and this ships as `1.9.1`.

## Test plan

- [x] Shared-link suite, 10 cases, all passing against the merged branch with the release dependency set. The same suite fails 5 cases on the pre-fix commit, so it is load-bearing.
- [x] Local-invite regression suite, 5 cases, all passing.
- [x] TikTok extraction verified end to end on 2026.8.19 without the `--referer` flag.
- [x] UI fix verified in a browser at 360, 390, 768 and 1280 px, in both themes, across both upload paths, with short names, the reported tiktok filename, and an 80-character unbroken name. No row scrolls wider than its box, no horizontal page scroll, every status sits 17px inside its card edge.
- [x] Trivy: 0 HIGH, 0 CRITICAL, 0 MEDIUM.
- [ ] Image built, scanned, and pushed as `1.9.1`.
- [ ] `latest` still points at 1.8.2. It gets repointed after this merges, not from the release branch.

No `./tests` directory exists in this project, so no unit test suite was run. The suites above are integration tests driven against a stand-in Immich, plus browser verification for the UI change.
